### PR TITLE
WIP: Inventory libkv

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -266,6 +266,10 @@
 			"Rev": "0bbddae09c5a5419a8c6dcdd7ff90da3d450393b"
 		},
 		{
+			"ImportPath": "github.com/docker/libkv",
+			"Rev": "8fc395a354d73bd69a373ddb052e0bae0fd15aa4"
+		},
+		{
 			"ImportPath": "github.com/go-ini/ini",
 			"Comment": "v0-56-g03e0e7d",
 			"Rev": "03e0e7d51a13a91c765d8d0161246bc14a38001a"
@@ -607,6 +611,25 @@
 			"ImportPath": "google.golang.org/cloud/compute/metadata",
 			"Rev": "975617b05ea8a58727e6c1a06b6161ff4185a9f2"
 		},
+		{
+			"ImportPath": "github.com/docker/libkv",
+			"Rev": "8fc395a354d73bd69a373ddb052e0bae0fd15aa4"
+		},
+                {
+                        "ImportPath": "github.com/coreos/etcd/client",
+                        "Comment": "v2.2.0-alpha.1-132-g25c87f1",
+                        "Rev": "25c87f13fdc678c1f02a34ae8ca0171ff25e764f"
+                },
+                {
+                        "ImportPath": "github.com/coreos/etcd/pkg/pathutil",
+                        "Comment": "v2.2.0-alpha.1-132-g25c87f1",
+                        "Rev": "25c87f13fdc678c1f02a34ae8ca0171ff25e764f"
+                },
+                {
+                        "ImportPath": "github.com/coreos/etcd/pkg/types",
+                        "Comment": "v2.2.0-alpha.1-132-g25c87f1",
+                        "Rev": "25c87f13fdc678c1f02a34ae8ca0171ff25e764f"
+                },
 		{
 			"ImportPath": "google.golang.org/cloud/internal",
 			"Rev": "975617b05ea8a58727e6c1a06b6161ff4185a9f2"

--- a/cmd/machine.go
+++ b/cmd/machine.go
@@ -124,6 +124,12 @@ The '--tls-ca-key' flag is not supported when using a remote CA.`
 			Usage:  "Configures storage path",
 		},
 		cli.StringFlag{
+			EnvVar: "MACHINE_KV_URL",
+			Name:   "kv-url",
+			Value:  "",
+			Usage:  "Configures KV store URL (optional)",
+		},
+		cli.StringFlag{
 			EnvVar: "MACHINE_CERT_PATH",
 			Name:   "cert-path",
 			Value:  mcndirs.GetMachineCertDir(),

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -142,14 +142,14 @@ func runAction(actionName string, c CommandLine, api libmachine.API) error {
 
 func runCommand(command func(commandLine CommandLine, api libmachine.API) error) func(context *cli.Context) {
 	return func(context *cli.Context) {
-		api := libmachine.NewClient(mcndirs.GetBaseDir(), context.GlobalString("cert-path"))
+		api := libmachine.NewClient(context.GlobalString("storage-path"), context.GlobalString("cert-path"))
 		defer api.Close()
 
 		if context.GlobalBool("native-ssh") {
 			api.SSHClientType = ssh.Native
 		}
 		api.GithubAPIToken = context.GlobalString("github-api-token")
-		api.Filestore.Path = context.GlobalString("storage-path")
+		//api.Store.Path = context.GlobalString("storage-path")
 
 		ca := context.GlobalString("ca")
 		if ca != "" {
@@ -161,7 +161,8 @@ func runCommand(command func(commandLine CommandLine, api libmachine.API) error)
 		// not through their respective modules.  For now, however,
 		// they are also being set the way that they originally were
 		// set to preserve backwards compatibility.
-		mcndirs.BaseDir = api.Filestore.Path
+		//mcndirs.BaseDir = api.Store.Path
+		mcndirs.BaseDir = context.GlobalString("storage-path")
 		mcnutils.GithubAPIToken = api.GithubAPIToken
 		ssh.SetDefaultClient(api.SSHClientType)
 

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -142,7 +142,7 @@ func runAction(actionName string, c CommandLine, api libmachine.API) error {
 
 func runCommand(command func(commandLine CommandLine, api libmachine.API) error) func(context *cli.Context) {
 	return func(context *cli.Context) {
-		api := libmachine.NewClient(context.GlobalString("storage-path"), context.GlobalString("cert-path"))
+		api := libmachine.NewClient(context.GlobalString("storage-path"), context.GlobalString("cert-path"), context.GlobalString("kv-url"))
 		defer api.Close()
 
 		if context.GlobalBool("native-ssh") {

--- a/libmachine/drivers/base.go
+++ b/libmachine/drivers/base.go
@@ -3,6 +3,8 @@ package drivers
 import (
 	"errors"
 	"path/filepath"
+
+	"github.com/docker/machine/libmachine/log"
 )
 
 const (
@@ -75,6 +77,8 @@ func (d *BaseDriver) PreCreateCheck() error {
 
 // ResolveStorePath returns the store path where the machine is
 func (d *BaseDriver) ResolveStorePath(file string) string {
+	// XXX this is wrong but I don't remember what it should do
+	log.Debugf("AK: resolvestorepath: %s", d.StorePath)
 	return filepath.Join(d.StorePath, "machines", d.MachineName, file)
 }
 

--- a/libmachine/kv/kv.go
+++ b/libmachine/kv/kv.go
@@ -21,10 +21,10 @@ const MachineKvPrefix = "machine/v0"
 var kvStore store.Store
 
 func Connect(kvHost string) (err error) {
-	log.Infof("AK: connect %d: %s", os.Getpid(), kvHost)
+	log.Debugf("AK: connect %d: %s", os.Getpid(), kvHost)
 	// TODO - figure out how to get TLS support in here...
 	if kvStore != nil {
-		log.Infof("AK: redundant connect, ignoring")
+		log.Debugf("AK: redundant connect, ignoring")
 		return nil
 	}
 	etcd.Register()
@@ -43,7 +43,7 @@ func Connect(kvHost string) (err error) {
 }
 
 func KvList(dir string) (kvList []*store.KVPair, err error) {
-	log.Infof("AK: list %d", os.Getpid())
+	log.Debugf("AK: list %d", os.Getpid())
 	if kvStore == nil {
 		panic(fmt.Errorf("KVStore not initialized!!"))
 	}
@@ -57,7 +57,7 @@ func KvList(dir string) (kvList []*store.KVPair, err error) {
 }
 
 func KvPut(path string, data []byte) (err error) {
-	log.Infof("AK: put %d", os.Getpid())
+	log.Debugf("AK: put %d", os.Getpid())
 	if kvStore == nil {
 		panic(fmt.Errorf("KVStore not initialized!!"))
 	}
@@ -71,7 +71,7 @@ func addPrefix(key string) string {
 }
 
 func KvLoad(key string) (kvPair *store.KVPair, err error) {
-	log.Infof("AK: load %d", os.Getpid())
+	log.Debugf("AK: load %d", os.Getpid())
 	if kvStore == nil {
 		panic(fmt.Errorf("KVStore not initialized!!"))
 	}
@@ -80,7 +80,7 @@ func KvLoad(key string) (kvPair *store.KVPair, err error) {
 }
 
 func KvExists(key string) (exists bool, err error) {
-	log.Infof("AK: exists %d", os.Getpid())
+	log.Debugf("AK: exists %d", os.Getpid())
 	if kvStore == nil {
 		panic(fmt.Errorf("KVStore not initialized!!"))
 	}

--- a/libmachine/kv/kv.go
+++ b/libmachine/kv/kv.go
@@ -1,0 +1,47 @@
+package kv
+
+// libkv layer for machine
+// holds globals and initial functions for libkv usage
+// put this here to avoid import loops in other code areas
+
+import (
+	"time"
+
+	"github.com/docker/libkv"
+	"github.com/docker/libkv/store"
+	"github.com/docker/libkv/store/etcd"
+	"github.com/docker/machine/libmachine/log"
+)
+
+const MachineKvPrefix = "machine/v0"
+
+var kvStore store.Store
+
+func Connect(BaseDir string) (err error) {
+	// TODO - figure out how to get TLS support in here...
+	etcd.Register()
+	kvStore, err = libkv.NewStore(store.ETCD,
+		[]string{BaseDir},
+		&store.Config{
+			ConnectionTimeout: 10 * time.Second,
+		},
+	)
+
+	return err
+}
+
+func KvList(dir string) (kvList []*store.KVPair, err error) {
+	log.Debugf("Looking for kv data at %s", dir)
+	kvList, err = kvStore.List(dir)
+	if err == store.ErrKeyNotFound {
+		return kvList, nil
+	}
+
+	log.Debugf("Got data: %s", kvList)
+	return kvList, err
+}
+
+func KvLoad(key string) (kvPair *store.KVPair, err error) {
+	kvPair, err = kvStore.Get(key)
+	return kvPair, err
+}

--- a/libmachine/kv/kv.go
+++ b/libmachine/kv/kv.go
@@ -91,3 +91,11 @@ func KvExists(key string) (exists bool, err error) {
 	}
 	return exists, err
 }
+
+func KvDeleteTree(key string) error {
+	log.Debugf("AK: exists %d", os.Getpid())
+	if kvStore == nil {
+		panic(fmt.Errorf("KVStore not initialized!!"))
+	}
+	return kvStore.DeleteTree(addPrefix(key))
+}

--- a/libmachine/libmachine.go
+++ b/libmachine/libmachine.go
@@ -2,9 +2,9 @@ package libmachine
 
 import (
 	"fmt"
-	"path/filepath"
-
 	"io"
+	"net/url"
+	"path/filepath"
 
 	"github.com/docker/machine/drivers/errdriver"
 	"github.com/docker/machine/libmachine/auth"
@@ -31,7 +31,6 @@ type API interface {
 	NewHost(driverName string, rawDriver []byte) (*host.Host, error)
 	Create(h *host.Host) error
 	persist.Store
-	GetMachinesDir() string
 }
 
 type Client struct {
@@ -40,16 +39,40 @@ type Client struct {
 	IsDebug        bool
 	SSHClientType  ssh.ClientType
 	GithubAPIToken string
-	*persist.Filestore
+	//*persist.Filestore
+	persist.Store
 	clientDriverFactory rpcdriver.RPCClientDriverFactory
 }
 
 func NewClient(storePath, certsDir string) *Client {
+	// Determine which type of store to generate
+	log.Debugf("In NewClient(%s, %s)", storePath, certsDir)
+	var store persist.Store
+	storeURL, err := url.Parse(storePath)
+	if err == nil {
+		log.Debugf("Parsed URL Scheme: %s", storeURL.Scheme)
+		log.Debugf("Parsed URL Host: %s", storeURL.Host)
+		log.Debugf("Parsed URL Path: %s", storeURL.Path)
+		// The scheme will be blank on unix paths, might be a drive letter (single char)
+		// or a multi-character scheme that libkv will hopefully handle
+		if len(storeURL.Scheme) > 1 {
+			log.Debugf("Generated new KV store")
+			store = persist.NewKvstore(storePath, certsDir)
+		}
+	} else {
+		log.Debugf("Failed to parse: %s", err)
+	}
+	if store == nil {
+		log.Debugf("Generated new file store")
+		store = persist.NewFilestore(storePath, certsDir, certsDir)
+	}
+
 	return &Client{
-		certsDir:            certsDir,
-		IsDebug:             false,
-		SSHClientType:       ssh.External,
-		Filestore:           persist.NewFilestore(storePath, certsDir, certsDir),
+		certsDir:      certsDir,
+		IsDebug:       false,
+		SSHClientType: ssh.External,
+		//Filestore:           persist.NewFilestore(storePath, certsDir, certsDir),
+		Store:               store,
 		clientDriverFactory: rpcdriver.NewRPCClientDriverFactory(),
 	}
 }
@@ -90,7 +113,7 @@ func (api *Client) NewHost(driverName string, rawDriver []byte) (*host.Host, err
 }
 
 func (api *Client) Load(name string) (*host.Host, error) {
-	h, err := api.Filestore.Load(name)
+	h, err := api.Store.Load(name)
 	if err != nil {
 		return nil, err
 	}
@@ -198,4 +221,8 @@ func (api *Client) performCreate(h *host.Host) error {
 
 func (api *Client) Close() error {
 	return api.clientDriverFactory.Close()
+}
+
+func (api *Client) GetMachinesDir() string {
+	return api.Store.GetMachinesDir()
 }

--- a/libmachine/mcnutils/utils.go
+++ b/libmachine/mcnutils/utils.go
@@ -9,6 +9,8 @@ import (
 	"runtime"
 	"strconv"
 	"time"
+
+	"github.com/docker/machine/libmachine/log"
 )
 
 // GetHomeDir returns the home directory
@@ -40,6 +42,7 @@ func GetUsername() string {
 }
 
 func CopyFile(src, dst string) error {
+	log.Debugf("XXX: copyfile %s -> %s", src, dst)
 	in, err := os.Open(src)
 	if err != nil {
 		return err

--- a/libmachine/persist/kvstore.go
+++ b/libmachine/persist/kvstore.go
@@ -24,7 +24,7 @@ type Kvstore struct {
 }
 
 func NewKvstore(path string) *Kvstore {
-	log.Infof("XXX NewKvstore(%s)", path)
+	log.Debugf("AK: NewKvstore(%s)", path)
 	kvurl, err := url.Parse(path)
 	if err != nil {
 		panic(fmt.Sprintf("Malformed store path: %s %s", path, err))

--- a/libmachine/persist/kvstore.go
+++ b/libmachine/persist/kvstore.go
@@ -127,7 +127,9 @@ func (s Kvstore) List() (results []string, err error) {
 }
 
 func (s Kvstore) Remove(name string) error {
-	return fmt.Errorf("NYI: Remove")
+	machinePath := getMachineBase(name)
+	log.Debugf("AK: deleting %s", machinePath)
+	return kv.KvDeleteTree(machinePath)
 }
 
 func (s Kvstore) GetMachinesDir() string {

--- a/libmachine/persist/kvstore.go
+++ b/libmachine/persist/kvstore.go
@@ -1,0 +1,134 @@
+package persist
+
+import (
+	"fmt"
+	"net/url"
+	"path"
+
+	"github.com/docker/machine/libmachine/host"
+	"github.com/docker/machine/libmachine/kv"
+	"github.com/docker/machine/libmachine/log"
+)
+
+func init() {
+	// XXX do we need this?
+	//etcd.Register()
+	//consul.Register()
+	//zookeeper.Register()
+	//boltdb.Register()
+}
+
+type Kvstore struct {
+	Path string // compat
+}
+
+func NewKvstore(path string, certsDir string) *Kvstore {
+	log.Debugf("XXX NewKvstore(%s, %s)", path, certsDir)
+	kvurl, err := url.Parse(path)
+	if err != nil {
+		panic(fmt.Sprintf("Malformed store path: %s %s", path, err))
+	}
+	switch kvurl.Scheme {
+	case "etcd":
+		err := kv.Connect(kvurl.Host)
+		if err != nil {
+			panic(err)
+		}
+		// TODO other KV store types
+	default:
+		panic(fmt.Sprintf("Unsupporetd KV store type: %s", kvurl.Scheme))
+	}
+
+	return &Kvstore{}
+}
+
+func (s Kvstore) Save(host *host.Host) error {
+	return fmt.Errorf("NYI: Save")
+}
+
+func (s Kvstore) Exists(name string) (bool, error) {
+	return false, fmt.Errorf("NYI: Exists")
+}
+
+func (s Kvstore) loadConfig(h *host.Host, data []byte) error {
+	// Remember the machine name so we don't have to pass it through each
+	// struct in the migration.
+	name := h.Name
+
+	migratedHost, migrationPerformed, err := host.MigrateHost(h, data)
+	if err != nil {
+		return fmt.Errorf("Error getting migrated host: %s", err)
+	}
+
+	*h = *migratedHost
+
+	h.Name = name
+
+	// If we end up performing a migration, we should save afterwards so we don't have to do it again on subsequent invocations.
+	log.Debugf("AK: migration performed: %v", migrationPerformed)
+	if migrationPerformed {
+		// XXX TODO do we want to save?
+
+		//		if err := s.saveToFile(data, filepath.Join(s.GetMachinesDir(), h.Name, "config.json.bak")); err != nil {
+		//			return fmt.Errorf("Error attempting to save backup after migration: %s", err)
+		//		}
+		//
+		//		if err := s.Save(h); err != nil {
+		//			return fmt.Errorf("Error saving config after migration was performed: %s", err)
+		//		}
+	}
+
+	return nil
+}
+
+func (s Kvstore) Load(name string) (loadedHost *host.Host, err error) {
+	log.Debugf("XXX Load input name is -> %s", name)
+	machinePath := path.Join(kv.MachineKvPrefix, "machines", name, "config.json")
+	kvPair, err := kv.KvLoad(machinePath)
+	if err != nil {
+		return nil, err
+	}
+
+	loadedHost = &host.Host{
+		Name: name,
+	}
+
+	if err := s.loadConfig(loadedHost, kvPair.Value); err != nil {
+		return nil, err
+	}
+
+	return loadedHost, nil
+}
+
+func (s Kvstore) List() (results []string, err error) {
+	machinePath := path.Join(kv.MachineKvPrefix, "machines")
+	log.Infof("AK: machine path %s", machinePath)
+
+	kvList, err := kv.KvList(machinePath)
+	if err != nil {
+		return results, err
+	}
+
+	for _, kvPair := range kvList {
+		log.Debugf("Found %s", kvPair.Key)
+		results = append(results, path.Base(kvPair.Key))
+	}
+
+	return results, err
+}
+
+func (s Kvstore) Remove(name string) error {
+	return fmt.Errorf("NYI: Remove")
+}
+
+func (s Kvstore) GetMachinesDir() string {
+	log.Warnf("XXX: NYI: GetMachinesDir (do we want this?!)")
+	return ""
+	//	url2 := s.storeURL
+	//	url2.Path = mcnutils.Join(s.prefix, MachinePrefix, "machines")
+	//	return url2.String()
+}
+
+func (s Kvstore) ListMachineFiles(host *host.Host) ([]string, error) {
+	return []string{}, fmt.Errorf("NYI: ListMachineFiles")
+}

--- a/libmachine/persist/store.go
+++ b/libmachine/persist/store.go
@@ -19,6 +19,8 @@ type Store interface {
 
 	// Save persists a machine in the store
 	Save(host *host.Host) error
+
+	GetMachinesDir() string
 }
 
 func LoadHosts(s Store, hostNames []string) ([]*host.Host, map[string]error) {

--- a/libmachine/ssh/keys.go
+++ b/libmachine/ssh/keys.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"runtime"
 
+	"github.com/docker/machine/libmachine/log"
 	gossh "golang.org/x/crypto/ssh"
 )
 
@@ -115,6 +116,7 @@ func GenerateSSHKey(path string) error {
 			return fmt.Errorf("Error generating key pair: %s", err)
 		}
 
+		log.Debugf("AK: writing to %s, %s.pub", path, path)
 		if err := kp.WriteToFile(path, fmt.Sprintf("%s.pub", path)); err != nil {
 			return fmt.Errorf("Error writing keys to file(s): %s", err)
 		}

--- a/run-etcd.sh
+++ b/run-etcd.sh
@@ -2,4 +2,4 @@
 
 HostIP=127.0.0.1
 
-docker run --rm -v /usr/share/ca-certificates/:/etc/ssl/certs -p 4001:4001 -p 2380:2380 -p 2379:2379 --name etcd docker/ucp-etcd:1.0.4 -name etcd0 -advertise-client-urls http://${HostIP}:2379,http://${HostIP}:4001 -listen-client-urls http://0.0.0.0:2379,http://0.0.0.0:4001 -initial-advertise-peer-urls http://${HostIP}:2380 -listen-peer-urls http://0.0.0.0:2380 -initial-cluster-token etcd-cluster-1 -initial-cluster etcd0=http://${HostIP}:2380 -initial-cluster-state new
+docker run --rm -v /usr/share/ca-certificates/:/etc/ssl/certs -p 4001:4001 -p 2380:2380 -p 2379:2379 -h etcd0 --name etcd docker/ucp-etcd:1.0.4 -name etcd0 -advertise-client-urls http://${HostIP}:2379,http://${HostIP}:4001 -listen-client-urls http://0.0.0.0:2379,http://0.0.0.0:4001 -initial-advertise-peer-urls http://${HostIP}:2380 -listen-peer-urls http://0.0.0.0:2380 -initial-cluster-token etcd-cluster-1 -initial-cluster etcd0=http://${HostIP}:2380 -initial-cluster-state new

--- a/run-etcd.sh
+++ b/run-etcd.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+HostIP=127.0.0.1
+
+docker run --rm -v /usr/share/ca-certificates/:/etc/ssl/certs -p 4001:4001 -p 2380:2380 -p 2379:2379 --name etcd docker/ucp-etcd:1.0.4 -name etcd0 -advertise-client-urls http://${HostIP}:2379,http://${HostIP}:4001 -listen-client-urls http://0.0.0.0:2379,http://0.0.0.0:4001 -initial-advertise-peer-urls http://${HostIP}:2380 -listen-peer-urls http://0.0.0.0:2380 -initial-cluster-token etcd-cluster-1 -initial-cluster etcd0=http://${HostIP}:2380 -initial-cluster-state new

--- a/vendor/github.com/coreos/etcd/client/README.md
+++ b/vendor/github.com/coreos/etcd/client/README.md
@@ -1,0 +1,94 @@
+# etcd/client
+
+etcd/client is the Go client library for etcd.
+
+[![GoDoc](https://godoc.org/github.com/coreos/etcd/client?status.png)](https://godoc.org/github.com/coreos/etcd/client)
+
+## Install
+
+```bash
+go get github.com/coreos/etcd/client
+```
+
+## Usage
+
+```go
+package main
+
+import (
+	"log"
+	"time"
+
+	"github.com/coreos/etcd/Godeps/_workspace/src/golang.org/x/net/context"
+	"github.com/coreos/etcd/client"
+)
+
+func main() {
+	cfg := client.Config{
+		Endpoints:               []string{"http://127.0.0.1:2379"},
+		Transport:               client.DefaultTransport,
+		// set timeout per request to fail fast when the target endpoint is unavailable
+		HeaderTimeoutPerRequest: time.Second,
+	}
+	c, err := client.New(cfg)
+	if err != nil {
+		log.Fatal(err)
+	}
+	kapi := client.NewKeysAPI(c)
+	resp, err := kapi.Set(context.Background(), "foo", "bar", nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```
+
+## Error Handling
+
+etcd client might return three types of errors.
+
+- context error
+
+Each API call has its first parameter as `context`. A context can be canceled or have an attached deadline. If the context is canceled or reaches its deadline, the responding context error will be returned no matter what internal errors the API call has already encountered.
+
+- cluster error
+
+Each API call tries to send request to the cluster endpoints one by one until it successfully gets a response. If a requests to an endpoint fails, due to exceeding per request timeout or connection issues, the error will be added into a list of errors. If all possible endpoints fail, a cluster error that includes all encountered errors will be returned.
+
+- response error
+
+If the response gets from the cluster is invalid, a plain string error will be returned. For example, it might be a invalid JSON error.
+
+Here is the example code to handle client errors:
+
+```go
+cfg := client.Config{Endpoints: []string{"http://etcd1:2379,http://etcd2:2379,http://etcd3:2379"}}
+c, err := client.New(cfg)
+if err != nil {
+	log.Fatal(err)
+}
+
+kapi := client.NewKeysAPI(c)
+resp, err := kapi.Set(ctx, "test", "bar", nil)
+if err != nil {
+	if err == context.Canceled {
+		// ctx is canceled by another routine
+	} else if err == context.DeadlineExceeded {
+		// ctx is attached with a deadline and it exceeded
+	} else if cerr, ok := err.(*client.ClusterError); ok {
+		// process (cerr.Errors)
+	} else {
+		// bad cluster endpoints, which are not etcd servers
+	}
+}
+```
+
+
+## Caveat
+
+1. etcd/client prefers to use the same endpoint as long as the endpoint continues to work well. This saves socket resources, and improves efficiency for both client and server side. This preference doesn't remove consistency from the data consumed by the client because data replicated to each etcd member has already passed through the consensus process.
+
+2. etcd/client does round-robin rotation on other available endpoints if the preferred endpoint isn't functioning properly. For example, if the member that etcd/client connects to is hard killed, etcd/client will fail on the first attempt with the killed member, and succeed on the second attempt with another member. If it fails to talk to all available endpoints, it will return all errors happened.
+
+3. Default etcd/client cannot handle the case that the remote server is SIGSTOPed now. TCP keepalive mechanism doesn't help in this scenario because operating system may still send TCP keep-alive packets. Over time we'd like to improve this functionality, but solving this issue isn't high priority because a real-life case in which a server is stopped, but the connection is kept alive, hasn't been brought to our attention.
+
+4. etcd/client cannot detect whether the member in use is healthy when doing read requests. If the member is isolated from the cluster, etcd/client may retrieve outdated data. As a workaround, users could monitor experimental /health endpoint for member healthy information. We are improving it at [#3265](https://github.com/coreos/etcd/issues/3265).

--- a/vendor/github.com/coreos/etcd/client/auth_role.go
+++ b/vendor/github.com/coreos/etcd/client/auth_role.go
@@ -1,0 +1,235 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/url"
+
+	"golang.org/x/net/context"
+)
+
+type Role struct {
+	Role        string       `json:"role"`
+	Permissions Permissions  `json:"permissions"`
+	Grant       *Permissions `json:"grant,omitempty"`
+	Revoke      *Permissions `json:"revoke,omitempty"`
+}
+
+type Permissions struct {
+	KV rwPermission `json:"kv"`
+}
+
+type rwPermission struct {
+	Read  []string `json:"read"`
+	Write []string `json:"write"`
+}
+
+type PermissionType int
+
+const (
+	ReadPermission PermissionType = iota
+	WritePermission
+	ReadWritePermission
+)
+
+// NewAuthRoleAPI constructs a new AuthRoleAPI that uses HTTP to
+// interact with etcd's role creation and modification features.
+func NewAuthRoleAPI(c Client) AuthRoleAPI {
+	return &httpAuthRoleAPI{
+		client: c,
+	}
+}
+
+type AuthRoleAPI interface {
+	// Add a role.
+	AddRole(ctx context.Context, role string) error
+
+	// Remove a role.
+	RemoveRole(ctx context.Context, role string) error
+
+	// Get role details.
+	GetRole(ctx context.Context, role string) (*Role, error)
+
+	// Grant a role some permission prefixes for the KV store.
+	GrantRoleKV(ctx context.Context, role string, prefixes []string, permType PermissionType) (*Role, error)
+
+	// Revoke some some permission prefixes for a role on the KV store.
+	RevokeRoleKV(ctx context.Context, role string, prefixes []string, permType PermissionType) (*Role, error)
+
+	// List roles.
+	ListRoles(ctx context.Context) ([]string, error)
+}
+
+type httpAuthRoleAPI struct {
+	client httpClient
+}
+
+type authRoleAPIAction struct {
+	verb string
+	name string
+	role *Role
+}
+
+type authRoleAPIList struct{}
+
+func (list *authRoleAPIList) HTTPRequest(ep url.URL) *http.Request {
+	u := v2AuthURL(ep, "roles", "")
+	req, _ := http.NewRequest("GET", u.String(), nil)
+	req.Header.Set("Content-Type", "application/json")
+	return req
+}
+
+func (l *authRoleAPIAction) HTTPRequest(ep url.URL) *http.Request {
+	u := v2AuthURL(ep, "roles", l.name)
+	if l.role == nil {
+		req, _ := http.NewRequest(l.verb, u.String(), nil)
+		return req
+	}
+	b, err := json.Marshal(l.role)
+	if err != nil {
+		panic(err)
+	}
+	body := bytes.NewReader(b)
+	req, _ := http.NewRequest(l.verb, u.String(), body)
+	req.Header.Set("Content-Type", "application/json")
+	return req
+}
+
+func (r *httpAuthRoleAPI) ListRoles(ctx context.Context) ([]string, error) {
+	resp, body, err := r.client.Do(ctx, &authRoleAPIList{})
+	if err != nil {
+		return nil, err
+	}
+	if err := assertStatusCode(resp.StatusCode, http.StatusOK); err != nil {
+		return nil, err
+	}
+	var userList struct {
+		Roles []string `json:"roles"`
+	}
+	err = json.Unmarshal(body, &userList)
+	if err != nil {
+		return nil, err
+	}
+	return userList.Roles, nil
+}
+
+func (r *httpAuthRoleAPI) AddRole(ctx context.Context, rolename string) error {
+	role := &Role{
+		Role: rolename,
+	}
+	return r.addRemoveRole(ctx, &authRoleAPIAction{
+		verb: "PUT",
+		name: rolename,
+		role: role,
+	})
+}
+
+func (r *httpAuthRoleAPI) RemoveRole(ctx context.Context, rolename string) error {
+	return r.addRemoveRole(ctx, &authRoleAPIAction{
+		verb: "DELETE",
+		name: rolename,
+	})
+}
+
+func (r *httpAuthRoleAPI) addRemoveRole(ctx context.Context, req *authRoleAPIAction) error {
+	resp, body, err := r.client.Do(ctx, req)
+	if err != nil {
+		return err
+	}
+	if err := assertStatusCode(resp.StatusCode, http.StatusOK, http.StatusCreated); err != nil {
+		var sec authError
+		err := json.Unmarshal(body, &sec)
+		if err != nil {
+			return err
+		}
+		return sec
+	}
+	return nil
+}
+
+func (r *httpAuthRoleAPI) GetRole(ctx context.Context, rolename string) (*Role, error) {
+	return r.modRole(ctx, &authRoleAPIAction{
+		verb: "GET",
+		name: rolename,
+	})
+}
+
+func buildRWPermission(prefixes []string, permType PermissionType) rwPermission {
+	var out rwPermission
+	switch permType {
+	case ReadPermission:
+		out.Read = prefixes
+	case WritePermission:
+		out.Write = prefixes
+	case ReadWritePermission:
+		out.Read = prefixes
+		out.Write = prefixes
+	}
+	return out
+}
+
+func (r *httpAuthRoleAPI) GrantRoleKV(ctx context.Context, rolename string, prefixes []string, permType PermissionType) (*Role, error) {
+	rwp := buildRWPermission(prefixes, permType)
+	role := &Role{
+		Role: rolename,
+		Grant: &Permissions{
+			KV: rwp,
+		},
+	}
+	return r.modRole(ctx, &authRoleAPIAction{
+		verb: "PUT",
+		name: rolename,
+		role: role,
+	})
+}
+
+func (r *httpAuthRoleAPI) RevokeRoleKV(ctx context.Context, rolename string, prefixes []string, permType PermissionType) (*Role, error) {
+	rwp := buildRWPermission(prefixes, permType)
+	role := &Role{
+		Role: rolename,
+		Revoke: &Permissions{
+			KV: rwp,
+		},
+	}
+	return r.modRole(ctx, &authRoleAPIAction{
+		verb: "PUT",
+		name: rolename,
+		role: role,
+	})
+}
+
+func (r *httpAuthRoleAPI) modRole(ctx context.Context, req *authRoleAPIAction) (*Role, error) {
+	resp, body, err := r.client.Do(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	if err := assertStatusCode(resp.StatusCode, http.StatusOK); err != nil {
+		var sec authError
+		err := json.Unmarshal(body, &sec)
+		if err != nil {
+			return nil, err
+		}
+		return nil, sec
+	}
+	var role Role
+	err = json.Unmarshal(body, &role)
+	if err != nil {
+		return nil, err
+	}
+	return &role, nil
+}

--- a/vendor/github.com/coreos/etcd/client/auth_user.go
+++ b/vendor/github.com/coreos/etcd/client/auth_user.go
@@ -1,0 +1,297 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"path"
+
+	"golang.org/x/net/context"
+)
+
+var (
+	defaultV2AuthPrefix = "/v2/auth"
+)
+
+type User struct {
+	User     string   `json:"user"`
+	Password string   `json:"password,omitempty"`
+	Roles    []string `json:"roles"`
+	Grant    []string `json:"grant,omitempty"`
+	Revoke   []string `json:"revoke,omitempty"`
+}
+
+func v2AuthURL(ep url.URL, action string, name string) *url.URL {
+	if name != "" {
+		ep.Path = path.Join(ep.Path, defaultV2AuthPrefix, action, name)
+		return &ep
+	}
+	ep.Path = path.Join(ep.Path, defaultV2AuthPrefix, action)
+	return &ep
+}
+
+// NewAuthAPI constructs a new AuthAPI that uses HTTP to
+// interact with etcd's general auth features.
+func NewAuthAPI(c Client) AuthAPI {
+	return &httpAuthAPI{
+		client: c,
+	}
+}
+
+type AuthAPI interface {
+	// Enable auth.
+	Enable(ctx context.Context) error
+
+	// Disable auth.
+	Disable(ctx context.Context) error
+}
+
+type httpAuthAPI struct {
+	client httpClient
+}
+
+func (s *httpAuthAPI) Enable(ctx context.Context) error {
+	return s.enableDisable(ctx, &authAPIAction{"PUT"})
+}
+
+func (s *httpAuthAPI) Disable(ctx context.Context) error {
+	return s.enableDisable(ctx, &authAPIAction{"DELETE"})
+}
+
+func (s *httpAuthAPI) enableDisable(ctx context.Context, req httpAction) error {
+	resp, body, err := s.client.Do(ctx, req)
+	if err != nil {
+		return err
+	}
+	if err := assertStatusCode(resp.StatusCode, http.StatusOK, http.StatusCreated); err != nil {
+		var sec authError
+		err := json.Unmarshal(body, &sec)
+		if err != nil {
+			return err
+		}
+		return sec
+	}
+	return nil
+}
+
+type authAPIAction struct {
+	verb string
+}
+
+func (l *authAPIAction) HTTPRequest(ep url.URL) *http.Request {
+	u := v2AuthURL(ep, "enable", "")
+	req, _ := http.NewRequest(l.verb, u.String(), nil)
+	return req
+}
+
+type authError struct {
+	Message string `json:"message"`
+	Code    int    `json:"-"`
+}
+
+func (e authError) Error() string {
+	return e.Message
+}
+
+// NewAuthUserAPI constructs a new AuthUserAPI that uses HTTP to
+// interact with etcd's user creation and modification features.
+func NewAuthUserAPI(c Client) AuthUserAPI {
+	return &httpAuthUserAPI{
+		client: c,
+	}
+}
+
+type AuthUserAPI interface {
+	// Add a user.
+	AddUser(ctx context.Context, username string, password string) error
+
+	// Remove a user.
+	RemoveUser(ctx context.Context, username string) error
+
+	// Get user details.
+	GetUser(ctx context.Context, username string) (*User, error)
+
+	// Grant a user some permission roles.
+	GrantUser(ctx context.Context, username string, roles []string) (*User, error)
+
+	// Revoke some permission roles from a user.
+	RevokeUser(ctx context.Context, username string, roles []string) (*User, error)
+
+	// Change the user's password.
+	ChangePassword(ctx context.Context, username string, password string) (*User, error)
+
+	// List users.
+	ListUsers(ctx context.Context) ([]string, error)
+}
+
+type httpAuthUserAPI struct {
+	client httpClient
+}
+
+type authUserAPIAction struct {
+	verb     string
+	username string
+	user     *User
+}
+
+type authUserAPIList struct{}
+
+func (list *authUserAPIList) HTTPRequest(ep url.URL) *http.Request {
+	u := v2AuthURL(ep, "users", "")
+	req, _ := http.NewRequest("GET", u.String(), nil)
+	req.Header.Set("Content-Type", "application/json")
+	return req
+}
+
+func (l *authUserAPIAction) HTTPRequest(ep url.URL) *http.Request {
+	u := v2AuthURL(ep, "users", l.username)
+	if l.user == nil {
+		req, _ := http.NewRequest(l.verb, u.String(), nil)
+		return req
+	}
+	b, err := json.Marshal(l.user)
+	if err != nil {
+		panic(err)
+	}
+	body := bytes.NewReader(b)
+	req, _ := http.NewRequest(l.verb, u.String(), body)
+	req.Header.Set("Content-Type", "application/json")
+	return req
+}
+
+func (u *httpAuthUserAPI) ListUsers(ctx context.Context) ([]string, error) {
+	resp, body, err := u.client.Do(ctx, &authUserAPIList{})
+	if err != nil {
+		return nil, err
+	}
+	if err := assertStatusCode(resp.StatusCode, http.StatusOK); err != nil {
+		var sec authError
+		err := json.Unmarshal(body, &sec)
+		if err != nil {
+			return nil, err
+		}
+		return nil, sec
+	}
+	var userList struct {
+		Users []string `json:"users"`
+	}
+	err = json.Unmarshal(body, &userList)
+	if err != nil {
+		return nil, err
+	}
+	return userList.Users, nil
+}
+
+func (u *httpAuthUserAPI) AddUser(ctx context.Context, username string, password string) error {
+	user := &User{
+		User:     username,
+		Password: password,
+	}
+	return u.addRemoveUser(ctx, &authUserAPIAction{
+		verb:     "PUT",
+		username: username,
+		user:     user,
+	})
+}
+
+func (u *httpAuthUserAPI) RemoveUser(ctx context.Context, username string) error {
+	return u.addRemoveUser(ctx, &authUserAPIAction{
+		verb:     "DELETE",
+		username: username,
+	})
+}
+
+func (u *httpAuthUserAPI) addRemoveUser(ctx context.Context, req *authUserAPIAction) error {
+	resp, body, err := u.client.Do(ctx, req)
+	if err != nil {
+		return err
+	}
+	if err := assertStatusCode(resp.StatusCode, http.StatusOK, http.StatusCreated); err != nil {
+		var sec authError
+		err := json.Unmarshal(body, &sec)
+		if err != nil {
+			return err
+		}
+		return sec
+	}
+	return nil
+}
+
+func (u *httpAuthUserAPI) GetUser(ctx context.Context, username string) (*User, error) {
+	return u.modUser(ctx, &authUserAPIAction{
+		verb:     "GET",
+		username: username,
+	})
+}
+
+func (u *httpAuthUserAPI) GrantUser(ctx context.Context, username string, roles []string) (*User, error) {
+	user := &User{
+		User:  username,
+		Grant: roles,
+	}
+	return u.modUser(ctx, &authUserAPIAction{
+		verb:     "PUT",
+		username: username,
+		user:     user,
+	})
+}
+
+func (u *httpAuthUserAPI) RevokeUser(ctx context.Context, username string, roles []string) (*User, error) {
+	user := &User{
+		User:   username,
+		Revoke: roles,
+	}
+	return u.modUser(ctx, &authUserAPIAction{
+		verb:     "PUT",
+		username: username,
+		user:     user,
+	})
+}
+
+func (u *httpAuthUserAPI) ChangePassword(ctx context.Context, username string, password string) (*User, error) {
+	user := &User{
+		User:     username,
+		Password: password,
+	}
+	return u.modUser(ctx, &authUserAPIAction{
+		verb:     "PUT",
+		username: username,
+		user:     user,
+	})
+}
+
+func (u *httpAuthUserAPI) modUser(ctx context.Context, req *authUserAPIAction) (*User, error) {
+	resp, body, err := u.client.Do(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	if err := assertStatusCode(resp.StatusCode, http.StatusOK); err != nil {
+		var sec authError
+		err := json.Unmarshal(body, &sec)
+		if err != nil {
+			return nil, err
+		}
+		return nil, sec
+	}
+	var user User
+	err = json.Unmarshal(body, &user)
+	if err != nil {
+		return nil, err
+	}
+	return &user, nil
+}

--- a/vendor/github.com/coreos/etcd/client/cancelreq.go
+++ b/vendor/github.com/coreos/etcd/client/cancelreq.go
@@ -1,0 +1,20 @@
+// Copyright 2015 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// borrowed from golang/net/context/ctxhttp/cancelreq.go
+
+// +build go1.5
+
+package client
+
+import "net/http"
+
+func requestCanceler(tr CancelableTransport, req *http.Request) func() {
+	ch := make(chan struct{})
+	req.Cancel = ch
+
+	return func() {
+		close(ch)
+	}
+}

--- a/vendor/github.com/coreos/etcd/client/cancelreq_go14.go
+++ b/vendor/github.com/coreos/etcd/client/cancelreq_go14.go
@@ -1,0 +1,17 @@
+// Copyright 2015 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// borrowed from golang/net/context/ctxhttp/cancelreq_go14.go
+
+// +build !go1.5
+
+package client
+
+import "net/http"
+
+func requestCanceler(tr CancelableTransport, req *http.Request) func() {
+	return func() {
+		tr.CancelRequest(req)
+	}
+}

--- a/vendor/github.com/coreos/etcd/client/client.go
+++ b/vendor/github.com/coreos/etcd/client/client.go
@@ -1,0 +1,514 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"math/rand"
+	"net"
+	"net/http"
+	"net/url"
+	"reflect"
+	"sort"
+	"sync"
+	"time"
+
+	"golang.org/x/net/context"
+)
+
+var (
+	ErrNoEndpoints           = errors.New("client: no endpoints available")
+	ErrTooManyRedirects      = errors.New("client: too many redirects")
+	ErrClusterUnavailable    = errors.New("client: etcd cluster is unavailable or misconfigured")
+	errTooManyRedirectChecks = errors.New("client: too many redirect checks")
+)
+
+var DefaultRequestTimeout = 5 * time.Second
+
+var DefaultTransport CancelableTransport = &http.Transport{
+	Proxy: http.ProxyFromEnvironment,
+	Dial: (&net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+	}).Dial,
+	TLSHandshakeTimeout: 10 * time.Second,
+}
+
+type Config struct {
+	// Endpoints defines a set of URLs (schemes, hosts and ports only)
+	// that can be used to communicate with a logical etcd cluster. For
+	// example, a three-node cluster could be provided like so:
+	//
+	// 	Endpoints: []string{
+	//		"http://node1.example.com:2379",
+	//		"http://node2.example.com:2379",
+	//		"http://node3.example.com:2379",
+	//	}
+	//
+	// If multiple endpoints are provided, the Client will attempt to
+	// use them all in the event that one or more of them are unusable.
+	//
+	// If Client.Sync is ever called, the Client may cache an alternate
+	// set of endpoints to continue operation.
+	Endpoints []string
+
+	// Transport is used by the Client to drive HTTP requests. If not
+	// provided, DefaultTransport will be used.
+	Transport CancelableTransport
+
+	// CheckRedirect specifies the policy for handling HTTP redirects.
+	// If CheckRedirect is not nil, the Client calls it before
+	// following an HTTP redirect. The sole argument is the number of
+	// requests that have alrady been made. If CheckRedirect returns
+	// an error, Client.Do will not make any further requests and return
+	// the error back it to the caller.
+	//
+	// If CheckRedirect is nil, the Client uses its default policy,
+	// which is to stop after 10 consecutive requests.
+	CheckRedirect CheckRedirectFunc
+
+	// Username specifies the user credential to add as an authorization header
+	Username string
+
+	// Password is the password for the specified user to add as an authorization header
+	// to the request.
+	Password string
+
+	// HeaderTimeoutPerRequest specifies the time limit to wait for response
+	// header in a single request made by the Client. The timeout includes
+	// connection time, any redirects, and header wait time.
+	//
+	// For non-watch GET request, server returns the response body immediately.
+	// For PUT/POST/DELETE request, server will attempt to commit request
+	// before responding, which is expected to take `100ms + 2 * RTT`.
+	// For watch request, server returns the header immediately to notify Client
+	// watch start. But if server is behind some kind of proxy, the response
+	// header may be cached at proxy, and Client cannot rely on this behavior.
+	//
+	// One API call may send multiple requests to different etcd servers until it
+	// succeeds. Use context of the API to specify the overall timeout.
+	//
+	// A HeaderTimeoutPerRequest of zero means no timeout.
+	HeaderTimeoutPerRequest time.Duration
+}
+
+func (cfg *Config) transport() CancelableTransport {
+	if cfg.Transport == nil {
+		return DefaultTransport
+	}
+	return cfg.Transport
+}
+
+func (cfg *Config) checkRedirect() CheckRedirectFunc {
+	if cfg.CheckRedirect == nil {
+		return DefaultCheckRedirect
+	}
+	return cfg.CheckRedirect
+}
+
+// CancelableTransport mimics net/http.Transport, but requires that
+// the object also support request cancellation.
+type CancelableTransport interface {
+	http.RoundTripper
+	CancelRequest(req *http.Request)
+}
+
+type CheckRedirectFunc func(via int) error
+
+// DefaultCheckRedirect follows up to 10 redirects, but no more.
+var DefaultCheckRedirect CheckRedirectFunc = func(via int) error {
+	if via > 10 {
+		return ErrTooManyRedirects
+	}
+	return nil
+}
+
+type Client interface {
+	// Sync updates the internal cache of the etcd cluster's membership.
+	Sync(context.Context) error
+
+	// AutoSync periodically calls Sync() every given interval.
+	// The recommended sync interval is 10 seconds to 1 minute, which does
+	// not bring too much overhead to server and makes client catch up the
+	// cluster change in time.
+	//
+	// The example to use it:
+	//
+	//  for {
+	//      err := client.AutoSync(ctx, 10*time.Second)
+	//      if err == context.DeadlineExceeded || err == context.Canceled {
+	//          break
+	//      }
+	//      log.Print(err)
+	//  }
+	AutoSync(context.Context, time.Duration) error
+
+	// Endpoints returns a copy of the current set of API endpoints used
+	// by Client to resolve HTTP requests. If Sync has ever been called,
+	// this may differ from the initial Endpoints provided in the Config.
+	Endpoints() []string
+
+	httpClient
+}
+
+func New(cfg Config) (Client, error) {
+	c := &httpClusterClient{
+		clientFactory: newHTTPClientFactory(cfg.transport(), cfg.checkRedirect(), cfg.HeaderTimeoutPerRequest),
+		rand:          rand.New(rand.NewSource(int64(time.Now().Nanosecond()))),
+	}
+	if cfg.Username != "" {
+		c.credentials = &credentials{
+			username: cfg.Username,
+			password: cfg.Password,
+		}
+	}
+	if err := c.reset(cfg.Endpoints); err != nil {
+		return nil, err
+	}
+	return c, nil
+}
+
+type httpClient interface {
+	Do(context.Context, httpAction) (*http.Response, []byte, error)
+}
+
+func newHTTPClientFactory(tr CancelableTransport, cr CheckRedirectFunc, headerTimeout time.Duration) httpClientFactory {
+	return func(ep url.URL) httpClient {
+		return &redirectFollowingHTTPClient{
+			checkRedirect: cr,
+			client: &simpleHTTPClient{
+				transport:     tr,
+				endpoint:      ep,
+				headerTimeout: headerTimeout,
+			},
+		}
+	}
+}
+
+type credentials struct {
+	username string
+	password string
+}
+
+type httpClientFactory func(url.URL) httpClient
+
+type httpAction interface {
+	HTTPRequest(url.URL) *http.Request
+}
+
+type httpClusterClient struct {
+	clientFactory httpClientFactory
+	endpoints     []url.URL
+	pinned        int
+	credentials   *credentials
+	sync.RWMutex
+	rand *rand.Rand
+}
+
+func (c *httpClusterClient) reset(eps []string) error {
+	if len(eps) == 0 {
+		return ErrNoEndpoints
+	}
+
+	neps := make([]url.URL, len(eps))
+	for i, ep := range eps {
+		u, err := url.Parse(ep)
+		if err != nil {
+			return err
+		}
+		neps[i] = *u
+	}
+
+	c.endpoints = shuffleEndpoints(c.rand, neps)
+	// TODO: pin old endpoint if possible, and rebalance when new endpoint appears
+	c.pinned = 0
+
+	return nil
+}
+
+func (c *httpClusterClient) Do(ctx context.Context, act httpAction) (*http.Response, []byte, error) {
+	action := act
+	c.RLock()
+	leps := len(c.endpoints)
+	eps := make([]url.URL, leps)
+	n := copy(eps, c.endpoints)
+	pinned := c.pinned
+
+	if c.credentials != nil {
+		action = &authedAction{
+			act:         act,
+			credentials: *c.credentials,
+		}
+	}
+	c.RUnlock()
+
+	if leps == 0 {
+		return nil, nil, ErrNoEndpoints
+	}
+
+	if leps != n {
+		return nil, nil, errors.New("unable to pick endpoint: copy failed")
+	}
+
+	var resp *http.Response
+	var body []byte
+	var err error
+	cerr := &ClusterError{}
+
+	for i := pinned; i < leps+pinned; i++ {
+		k := i % leps
+		hc := c.clientFactory(eps[k])
+		resp, body, err = hc.Do(ctx, action)
+		if err != nil {
+			cerr.Errors = append(cerr.Errors, err)
+			// mask previous errors with context error, which is controlled by user
+			if err == context.Canceled || err == context.DeadlineExceeded {
+				return nil, nil, err
+			}
+			continue
+		}
+		if resp.StatusCode/100 == 5 {
+			switch resp.StatusCode {
+			case http.StatusInternalServerError, http.StatusServiceUnavailable:
+				// TODO: make sure this is a no leader response
+				cerr.Errors = append(cerr.Errors, fmt.Errorf("client: etcd member %s has no leader", eps[k].String()))
+			default:
+				cerr.Errors = append(cerr.Errors, fmt.Errorf("client: etcd member %s returns server error [%s]", eps[k].String(), http.StatusText(resp.StatusCode)))
+			}
+			continue
+		}
+		if k != pinned {
+			c.Lock()
+			c.pinned = k
+			c.Unlock()
+		}
+		return resp, body, nil
+	}
+
+	return nil, nil, cerr
+}
+
+func (c *httpClusterClient) Endpoints() []string {
+	c.RLock()
+	defer c.RUnlock()
+
+	eps := make([]string, len(c.endpoints))
+	for i, ep := range c.endpoints {
+		eps[i] = ep.String()
+	}
+
+	return eps
+}
+
+func (c *httpClusterClient) Sync(ctx context.Context) error {
+	mAPI := NewMembersAPI(c)
+	ms, err := mAPI.List(ctx)
+	if err != nil {
+		return err
+	}
+
+	c.Lock()
+	defer c.Unlock()
+
+	eps := make([]string, 0)
+	for _, m := range ms {
+		eps = append(eps, m.ClientURLs...)
+	}
+	sort.Sort(sort.StringSlice(eps))
+
+	ceps := make([]string, len(c.endpoints))
+	for i, cep := range c.endpoints {
+		ceps[i] = cep.String()
+	}
+	sort.Sort(sort.StringSlice(ceps))
+	// fast path if no change happens
+	// this helps client to pin the endpoint when no cluster change
+	if reflect.DeepEqual(eps, ceps) {
+		return nil
+	}
+
+	return c.reset(eps)
+}
+
+func (c *httpClusterClient) AutoSync(ctx context.Context, interval time.Duration) error {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		err := c.Sync(ctx)
+		if err != nil {
+			return err
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+type roundTripResponse struct {
+	resp *http.Response
+	err  error
+}
+
+type simpleHTTPClient struct {
+	transport     CancelableTransport
+	endpoint      url.URL
+	headerTimeout time.Duration
+}
+
+func (c *simpleHTTPClient) Do(ctx context.Context, act httpAction) (*http.Response, []byte, error) {
+	req := act.HTTPRequest(c.endpoint)
+
+	if err := printcURL(req); err != nil {
+		return nil, nil, err
+	}
+
+	hctx, hcancel := context.WithCancel(ctx)
+	if c.headerTimeout > 0 {
+		hctx, hcancel = context.WithTimeout(ctx, c.headerTimeout)
+	}
+	defer hcancel()
+
+	reqcancel := requestCanceler(c.transport, req)
+
+	rtchan := make(chan roundTripResponse, 1)
+	go func() {
+		resp, err := c.transport.RoundTrip(req)
+		rtchan <- roundTripResponse{resp: resp, err: err}
+		close(rtchan)
+	}()
+
+	var resp *http.Response
+	var err error
+
+	select {
+	case rtresp := <-rtchan:
+		resp, err = rtresp.resp, rtresp.err
+	case <-hctx.Done():
+		// cancel and wait for request to actually exit before continuing
+		reqcancel()
+		rtresp := <-rtchan
+		resp = rtresp.resp
+		switch {
+		case ctx.Err() != nil:
+			err = ctx.Err()
+		case hctx.Err() != nil:
+			err = fmt.Errorf("client: endpoint %s exceeded header timeout", c.endpoint.String())
+		default:
+			panic("failed to get error from context")
+		}
+	}
+
+	// always check for resp nil-ness to deal with possible
+	// race conditions between channels above
+	defer func() {
+		if resp != nil {
+			resp.Body.Close()
+		}
+	}()
+
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var body []byte
+	done := make(chan struct{})
+	go func() {
+		body, err = ioutil.ReadAll(resp.Body)
+		done <- struct{}{}
+	}()
+
+	select {
+	case <-ctx.Done():
+		resp.Body.Close()
+		<-done
+		return nil, nil, ctx.Err()
+	case <-done:
+	}
+
+	return resp, body, err
+}
+
+type authedAction struct {
+	act         httpAction
+	credentials credentials
+}
+
+func (a *authedAction) HTTPRequest(url url.URL) *http.Request {
+	r := a.act.HTTPRequest(url)
+	r.SetBasicAuth(a.credentials.username, a.credentials.password)
+	return r
+}
+
+type redirectFollowingHTTPClient struct {
+	client        httpClient
+	checkRedirect CheckRedirectFunc
+}
+
+func (r *redirectFollowingHTTPClient) Do(ctx context.Context, act httpAction) (*http.Response, []byte, error) {
+	next := act
+	for i := 0; i < 100; i++ {
+		if i > 0 {
+			if err := r.checkRedirect(i); err != nil {
+				return nil, nil, err
+			}
+		}
+		resp, body, err := r.client.Do(ctx, next)
+		if err != nil {
+			return nil, nil, err
+		}
+		if resp.StatusCode/100 == 3 {
+			hdr := resp.Header.Get("Location")
+			if hdr == "" {
+				return nil, nil, fmt.Errorf("Location header not set")
+			}
+			loc, err := url.Parse(hdr)
+			if err != nil {
+				return nil, nil, fmt.Errorf("Location header not valid URL: %s", hdr)
+			}
+			next = &redirectedHTTPAction{
+				action:   act,
+				location: *loc,
+			}
+			continue
+		}
+		return resp, body, nil
+	}
+
+	return nil, nil, errTooManyRedirectChecks
+}
+
+type redirectedHTTPAction struct {
+	action   httpAction
+	location url.URL
+}
+
+func (r *redirectedHTTPAction) HTTPRequest(ep url.URL) *http.Request {
+	orig := r.action.HTTPRequest(ep)
+	orig.URL = &r.location
+	return orig
+}
+
+func shuffleEndpoints(r *rand.Rand, eps []url.URL) []url.URL {
+	p := r.Perm(len(eps))
+	neps := make([]url.URL, len(eps))
+	for i, k := range p {
+		neps[i] = eps[k]
+	}
+	return neps
+}

--- a/vendor/github.com/coreos/etcd/client/client_test.go
+++ b/vendor/github.com/coreos/etcd/client/client_test.go
@@ -1,0 +1,896 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"errors"
+	"io"
+	"io/ioutil"
+	"math/rand"
+	"net/http"
+	"net/url"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/coreos/etcd/pkg/testutil"
+	"golang.org/x/net/context"
+)
+
+type actionAssertingHTTPClient struct {
+	t   *testing.T
+	num int
+	act httpAction
+
+	resp http.Response
+	body []byte
+	err  error
+}
+
+func (a *actionAssertingHTTPClient) Do(_ context.Context, act httpAction) (*http.Response, []byte, error) {
+	if !reflect.DeepEqual(a.act, act) {
+		a.t.Errorf("#%d: unexpected httpAction: want=%#v got=%#v", a.num, a.act, act)
+	}
+
+	return &a.resp, a.body, a.err
+}
+
+type staticHTTPClient struct {
+	resp http.Response
+	body []byte
+	err  error
+}
+
+func (s *staticHTTPClient) Do(context.Context, httpAction) (*http.Response, []byte, error) {
+	return &s.resp, s.body, s.err
+}
+
+type staticHTTPAction struct {
+	request http.Request
+}
+
+func (s *staticHTTPAction) HTTPRequest(url.URL) *http.Request {
+	return &s.request
+}
+
+type staticHTTPResponse struct {
+	resp http.Response
+	body []byte
+	err  error
+}
+
+type multiStaticHTTPClient struct {
+	responses []staticHTTPResponse
+	cur       int
+}
+
+func (s *multiStaticHTTPClient) Do(context.Context, httpAction) (*http.Response, []byte, error) {
+	r := s.responses[s.cur]
+	s.cur++
+	return &r.resp, r.body, r.err
+}
+
+func newStaticHTTPClientFactory(responses []staticHTTPResponse) httpClientFactory {
+	var cur int
+	return func(url.URL) httpClient {
+		r := responses[cur]
+		cur++
+		return &staticHTTPClient{resp: r.resp, body: r.body, err: r.err}
+	}
+}
+
+type fakeTransport struct {
+	respchan     chan *http.Response
+	errchan      chan error
+	startCancel  chan struct{}
+	finishCancel chan struct{}
+}
+
+func newFakeTransport() *fakeTransport {
+	return &fakeTransport{
+		respchan:     make(chan *http.Response, 1),
+		errchan:      make(chan error, 1),
+		startCancel:  make(chan struct{}, 1),
+		finishCancel: make(chan struct{}, 1),
+	}
+}
+
+func (t *fakeTransport) CancelRequest(*http.Request) {
+	t.startCancel <- struct{}{}
+}
+
+type fakeAction struct{}
+
+func (a *fakeAction) HTTPRequest(url.URL) *http.Request {
+	return &http.Request{}
+}
+
+func TestSimpleHTTPClientDoSuccess(t *testing.T) {
+	tr := newFakeTransport()
+	c := &simpleHTTPClient{transport: tr}
+
+	tr.respchan <- &http.Response{
+		StatusCode: http.StatusTeapot,
+		Body:       ioutil.NopCloser(strings.NewReader("foo")),
+	}
+
+	resp, body, err := c.Do(context.Background(), &fakeAction{})
+	if err != nil {
+		t.Fatalf("incorrect error value: want=nil got=%v", err)
+	}
+
+	wantCode := http.StatusTeapot
+	if wantCode != resp.StatusCode {
+		t.Fatalf("invalid response code: want=%d got=%d", wantCode, resp.StatusCode)
+	}
+
+	wantBody := []byte("foo")
+	if !reflect.DeepEqual(wantBody, body) {
+		t.Fatalf("invalid response body: want=%q got=%q", wantBody, body)
+	}
+}
+
+func TestSimpleHTTPClientDoError(t *testing.T) {
+	tr := newFakeTransport()
+	c := &simpleHTTPClient{transport: tr}
+
+	tr.errchan <- errors.New("fixture")
+
+	_, _, err := c.Do(context.Background(), &fakeAction{})
+	if err == nil {
+		t.Fatalf("expected non-nil error, got nil")
+	}
+}
+
+func TestSimpleHTTPClientDoCancelContext(t *testing.T) {
+	tr := newFakeTransport()
+	c := &simpleHTTPClient{transport: tr}
+
+	tr.startCancel <- struct{}{}
+	tr.finishCancel <- struct{}{}
+
+	_, _, err := c.Do(context.Background(), &fakeAction{})
+	if err == nil {
+		t.Fatalf("expected non-nil error, got nil")
+	}
+}
+
+type checkableReadCloser struct {
+	io.ReadCloser
+	closed bool
+}
+
+func (c *checkableReadCloser) Close() error {
+	if !c.closed {
+		c.closed = true
+		return c.ReadCloser.Close()
+	}
+	return nil
+}
+
+func TestSimpleHTTPClientDoCancelContextResponseBodyClosed(t *testing.T) {
+	tr := newFakeTransport()
+	c := &simpleHTTPClient{transport: tr}
+
+	// create an already-cancelled context
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	body := &checkableReadCloser{ReadCloser: ioutil.NopCloser(strings.NewReader("foo"))}
+	go func() {
+		// wait that simpleHTTPClient knows the context is already timed out,
+		// and calls CancelRequest
+		testutil.WaitSchedule()
+
+		// response is returned before cancel effects
+		tr.respchan <- &http.Response{Body: body}
+	}()
+
+	_, _, err := c.Do(ctx, &fakeAction{})
+	if err == nil {
+		t.Fatalf("expected non-nil error, got nil")
+	}
+
+	if !body.closed {
+		t.Fatalf("expected closed body")
+	}
+}
+
+type blockingBody struct {
+	c chan struct{}
+}
+
+func (bb *blockingBody) Read(p []byte) (n int, err error) {
+	<-bb.c
+	return 0, errors.New("closed")
+}
+
+func (bb *blockingBody) Close() error {
+	close(bb.c)
+	return nil
+}
+
+func TestSimpleHTTPClientDoCancelContextResponseBodyClosedWithBlockingBody(t *testing.T) {
+	tr := newFakeTransport()
+	c := &simpleHTTPClient{transport: tr}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	body := &checkableReadCloser{ReadCloser: &blockingBody{c: make(chan struct{})}}
+	go func() {
+		tr.respchan <- &http.Response{Body: body}
+		time.Sleep(2 * time.Millisecond)
+		// cancel after the body is received
+		cancel()
+	}()
+
+	_, _, err := c.Do(ctx, &fakeAction{})
+	if err != context.Canceled {
+		t.Fatalf("expected %+v, got %+v", context.Canceled, err)
+	}
+
+	if !body.closed {
+		t.Fatalf("expected closed body")
+	}
+}
+
+func TestSimpleHTTPClientDoCancelContextWaitForRoundTrip(t *testing.T) {
+	tr := newFakeTransport()
+	c := &simpleHTTPClient{transport: tr}
+
+	donechan := make(chan struct{})
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		c.Do(ctx, &fakeAction{})
+		close(donechan)
+	}()
+
+	// This should call CancelRequest and begin the cancellation process
+	cancel()
+
+	select {
+	case <-donechan:
+		t.Fatalf("simpleHTTPClient.Do should not have exited yet")
+	default:
+	}
+
+	tr.finishCancel <- struct{}{}
+
+	select {
+	case <-donechan:
+		//expected behavior
+		return
+	case <-time.After(time.Second):
+		t.Fatalf("simpleHTTPClient.Do did not exit within 1s")
+	}
+}
+
+func TestSimpleHTTPClientDoHeaderTimeout(t *testing.T) {
+	tr := newFakeTransport()
+	tr.finishCancel <- struct{}{}
+	c := &simpleHTTPClient{transport: tr, headerTimeout: time.Millisecond}
+
+	errc := make(chan error)
+	go func() {
+		_, _, err := c.Do(context.Background(), &fakeAction{})
+		errc <- err
+	}()
+
+	select {
+	case err := <-errc:
+		if err == nil {
+			t.Fatalf("expected non-nil error, got nil")
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("unexpected timeout when waitting for the test to finish")
+	}
+}
+
+func TestHTTPClusterClientDo(t *testing.T) {
+	fakeErr := errors.New("fake!")
+	fakeURL := url.URL{}
+	tests := []struct {
+		client     *httpClusterClient
+		wantCode   int
+		wantErr    error
+		wantPinned int
+	}{
+		// first good response short-circuits Do
+		{
+			client: &httpClusterClient{
+				endpoints: []url.URL{fakeURL, fakeURL},
+				clientFactory: newStaticHTTPClientFactory(
+					[]staticHTTPResponse{
+						{resp: http.Response{StatusCode: http.StatusTeapot}},
+						{err: fakeErr},
+					},
+				),
+				rand: rand.New(rand.NewSource(0)),
+			},
+			wantCode: http.StatusTeapot,
+		},
+
+		// fall through to good endpoint if err is arbitrary
+		{
+			client: &httpClusterClient{
+				endpoints: []url.URL{fakeURL, fakeURL},
+				clientFactory: newStaticHTTPClientFactory(
+					[]staticHTTPResponse{
+						{err: fakeErr},
+						{resp: http.Response{StatusCode: http.StatusTeapot}},
+					},
+				),
+				rand: rand.New(rand.NewSource(0)),
+			},
+			wantCode:   http.StatusTeapot,
+			wantPinned: 1,
+		},
+
+		// context.Canceled short-circuits Do
+		{
+			client: &httpClusterClient{
+				endpoints: []url.URL{fakeURL, fakeURL},
+				clientFactory: newStaticHTTPClientFactory(
+					[]staticHTTPResponse{
+						{err: context.Canceled},
+						{resp: http.Response{StatusCode: http.StatusTeapot}},
+					},
+				),
+				rand: rand.New(rand.NewSource(0)),
+			},
+			wantErr: context.Canceled,
+		},
+
+		// return err if there are no endpoints
+		{
+			client: &httpClusterClient{
+				endpoints:     []url.URL{},
+				clientFactory: newHTTPClientFactory(nil, nil, 0),
+				rand:          rand.New(rand.NewSource(0)),
+			},
+			wantErr: ErrNoEndpoints,
+		},
+
+		// return err if all endpoints return arbitrary errors
+		{
+			client: &httpClusterClient{
+				endpoints: []url.URL{fakeURL, fakeURL},
+				clientFactory: newStaticHTTPClientFactory(
+					[]staticHTTPResponse{
+						{err: fakeErr},
+						{err: fakeErr},
+					},
+				),
+				rand: rand.New(rand.NewSource(0)),
+			},
+			wantErr: &ClusterError{Errors: []error{fakeErr, fakeErr}},
+		},
+
+		// 500-level errors cause Do to fallthrough to next endpoint
+		{
+			client: &httpClusterClient{
+				endpoints: []url.URL{fakeURL, fakeURL},
+				clientFactory: newStaticHTTPClientFactory(
+					[]staticHTTPResponse{
+						{resp: http.Response{StatusCode: http.StatusBadGateway}},
+						{resp: http.Response{StatusCode: http.StatusTeapot}},
+					},
+				),
+				rand: rand.New(rand.NewSource(0)),
+			},
+			wantCode:   http.StatusTeapot,
+			wantPinned: 1,
+		},
+	}
+
+	for i, tt := range tests {
+		resp, _, err := tt.client.Do(context.Background(), nil)
+		if !reflect.DeepEqual(tt.wantErr, err) {
+			t.Errorf("#%d: got err=%v, want=%v", i, err, tt.wantErr)
+			continue
+		}
+
+		if resp == nil {
+			if tt.wantCode != 0 {
+				t.Errorf("#%d: resp is nil, want=%d", i, tt.wantCode)
+			}
+			continue
+		}
+
+		if resp.StatusCode != tt.wantCode {
+			t.Errorf("#%d: resp code=%d, want=%d", i, resp.StatusCode, tt.wantCode)
+			continue
+		}
+
+		if tt.client.pinned != tt.wantPinned {
+			t.Errorf("#%d: pinned=%d, want=%d", i, tt.client.pinned, tt.wantPinned)
+		}
+	}
+}
+
+func TestHTTPClusterClientDoDeadlineExceedContext(t *testing.T) {
+	fakeURL := url.URL{}
+	tr := newFakeTransport()
+	tr.finishCancel <- struct{}{}
+	c := &httpClusterClient{
+		clientFactory: newHTTPClientFactory(tr, DefaultCheckRedirect, 0),
+		endpoints:     []url.URL{fakeURL},
+	}
+
+	errc := make(chan error)
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+		defer cancel()
+		_, _, err := c.Do(ctx, &fakeAction{})
+		errc <- err
+	}()
+
+	select {
+	case err := <-errc:
+		if err != context.DeadlineExceeded {
+			t.Errorf("err = %+v, want %+v", err, context.DeadlineExceeded)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("unexpected timeout when waitting for request to deadline exceed")
+	}
+}
+
+func TestRedirectedHTTPAction(t *testing.T) {
+	act := &redirectedHTTPAction{
+		action: &staticHTTPAction{
+			request: http.Request{
+				Method: "DELETE",
+				URL: &url.URL{
+					Scheme: "https",
+					Host:   "foo.example.com",
+					Path:   "/ping",
+				},
+			},
+		},
+		location: url.URL{
+			Scheme: "https",
+			Host:   "bar.example.com",
+			Path:   "/pong",
+		},
+	}
+
+	want := &http.Request{
+		Method: "DELETE",
+		URL: &url.URL{
+			Scheme: "https",
+			Host:   "bar.example.com",
+			Path:   "/pong",
+		},
+	}
+	got := act.HTTPRequest(url.URL{Scheme: "http", Host: "baz.example.com", Path: "/pang"})
+
+	if !reflect.DeepEqual(want, got) {
+		t.Fatalf("HTTPRequest is %#v, want %#v", want, got)
+	}
+}
+
+func TestRedirectFollowingHTTPClient(t *testing.T) {
+	tests := []struct {
+		checkRedirect CheckRedirectFunc
+		client        httpClient
+		wantCode      int
+		wantErr       error
+	}{
+		// errors bubbled up
+		{
+			checkRedirect: func(int) error { return ErrTooManyRedirects },
+			client: &multiStaticHTTPClient{
+				responses: []staticHTTPResponse{
+					{
+						err: errors.New("fail!"),
+					},
+				},
+			},
+			wantErr: errors.New("fail!"),
+		},
+
+		// no need to follow redirect if none given
+		{
+			checkRedirect: func(int) error { return ErrTooManyRedirects },
+			client: &multiStaticHTTPClient{
+				responses: []staticHTTPResponse{
+					{
+						resp: http.Response{
+							StatusCode: http.StatusTeapot,
+						},
+					},
+				},
+			},
+			wantCode: http.StatusTeapot,
+		},
+
+		// redirects if less than max
+		{
+			checkRedirect: func(via int) error {
+				if via >= 2 {
+					return ErrTooManyRedirects
+				}
+				return nil
+			},
+			client: &multiStaticHTTPClient{
+				responses: []staticHTTPResponse{
+					{
+						resp: http.Response{
+							StatusCode: http.StatusTemporaryRedirect,
+							Header:     http.Header{"Location": []string{"http://example.com"}},
+						},
+					},
+					{
+						resp: http.Response{
+							StatusCode: http.StatusTeapot,
+						},
+					},
+				},
+			},
+			wantCode: http.StatusTeapot,
+		},
+
+		// succeed after reaching max redirects
+		{
+			checkRedirect: func(via int) error {
+				if via >= 3 {
+					return ErrTooManyRedirects
+				}
+				return nil
+			},
+			client: &multiStaticHTTPClient{
+				responses: []staticHTTPResponse{
+					{
+						resp: http.Response{
+							StatusCode: http.StatusTemporaryRedirect,
+							Header:     http.Header{"Location": []string{"http://example.com"}},
+						},
+					},
+					{
+						resp: http.Response{
+							StatusCode: http.StatusTemporaryRedirect,
+							Header:     http.Header{"Location": []string{"http://example.com"}},
+						},
+					},
+					{
+						resp: http.Response{
+							StatusCode: http.StatusTeapot,
+						},
+					},
+				},
+			},
+			wantCode: http.StatusTeapot,
+		},
+
+		// fail if too many redirects
+		{
+			checkRedirect: func(via int) error {
+				if via >= 2 {
+					return ErrTooManyRedirects
+				}
+				return nil
+			},
+			client: &multiStaticHTTPClient{
+				responses: []staticHTTPResponse{
+					{
+						resp: http.Response{
+							StatusCode: http.StatusTemporaryRedirect,
+							Header:     http.Header{"Location": []string{"http://example.com"}},
+						},
+					},
+					{
+						resp: http.Response{
+							StatusCode: http.StatusTemporaryRedirect,
+							Header:     http.Header{"Location": []string{"http://example.com"}},
+						},
+					},
+					{
+						resp: http.Response{
+							StatusCode: http.StatusTeapot,
+						},
+					},
+				},
+			},
+			wantErr: ErrTooManyRedirects,
+		},
+
+		// fail if Location header not set
+		{
+			checkRedirect: func(int) error { return ErrTooManyRedirects },
+			client: &multiStaticHTTPClient{
+				responses: []staticHTTPResponse{
+					{
+						resp: http.Response{
+							StatusCode: http.StatusTemporaryRedirect,
+						},
+					},
+				},
+			},
+			wantErr: errors.New("Location header not set"),
+		},
+
+		// fail if Location header is invalid
+		{
+			checkRedirect: func(int) error { return ErrTooManyRedirects },
+			client: &multiStaticHTTPClient{
+				responses: []staticHTTPResponse{
+					{
+						resp: http.Response{
+							StatusCode: http.StatusTemporaryRedirect,
+							Header:     http.Header{"Location": []string{":"}},
+						},
+					},
+				},
+			},
+			wantErr: errors.New("Location header not valid URL: :"),
+		},
+
+		// fail if redirects checked way too many times
+		{
+			checkRedirect: func(int) error { return nil },
+			client: &staticHTTPClient{
+				resp: http.Response{
+					StatusCode: http.StatusTemporaryRedirect,
+					Header:     http.Header{"Location": []string{"http://example.com"}},
+				},
+			},
+			wantErr: errTooManyRedirectChecks,
+		},
+	}
+
+	for i, tt := range tests {
+		client := &redirectFollowingHTTPClient{client: tt.client, checkRedirect: tt.checkRedirect}
+		resp, _, err := client.Do(context.Background(), nil)
+		if !reflect.DeepEqual(tt.wantErr, err) {
+			t.Errorf("#%d: got err=%v, want=%v", i, err, tt.wantErr)
+			continue
+		}
+
+		if resp == nil {
+			if tt.wantCode != 0 {
+				t.Errorf("#%d: resp is nil, want=%d", i, tt.wantCode)
+			}
+			continue
+		}
+
+		if resp.StatusCode != tt.wantCode {
+			t.Errorf("#%d: resp code=%d, want=%d", i, resp.StatusCode, tt.wantCode)
+			continue
+		}
+	}
+}
+
+func TestDefaultCheckRedirect(t *testing.T) {
+	tests := []struct {
+		num int
+		err error
+	}{
+		{0, nil},
+		{5, nil},
+		{10, nil},
+		{11, ErrTooManyRedirects},
+		{29, ErrTooManyRedirects},
+	}
+
+	for i, tt := range tests {
+		err := DefaultCheckRedirect(tt.num)
+		if !reflect.DeepEqual(tt.err, err) {
+			t.Errorf("#%d: want=%#v got=%#v", i, tt.err, err)
+		}
+	}
+}
+
+func TestHTTPClusterClientSync(t *testing.T) {
+	cf := newStaticHTTPClientFactory([]staticHTTPResponse{
+		{
+			resp: http.Response{StatusCode: http.StatusOK, Header: http.Header{"Content-Type": []string{"application/json"}}},
+			body: []byte(`{"members":[{"id":"2745e2525fce8fe","peerURLs":["http://127.0.0.1:7003"],"name":"node3","clientURLs":["http://127.0.0.1:4003"]},{"id":"42134f434382925","peerURLs":["http://127.0.0.1:2380","http://127.0.0.1:7001"],"name":"node1","clientURLs":["http://127.0.0.1:2379","http://127.0.0.1:4001"]},{"id":"94088180e21eb87b","peerURLs":["http://127.0.0.1:7002"],"name":"node2","clientURLs":["http://127.0.0.1:4002"]}]}`),
+		},
+	})
+
+	hc := &httpClusterClient{
+		clientFactory: cf,
+		rand:          rand.New(rand.NewSource(0)),
+	}
+	err := hc.reset([]string{"http://127.0.0.1:2379"})
+	if err != nil {
+		t.Fatalf("unexpected error during setup: %#v", err)
+	}
+
+	want := []string{"http://127.0.0.1:2379"}
+	got := hc.Endpoints()
+	if !reflect.DeepEqual(want, got) {
+		t.Fatalf("incorrect endpoints: want=%#v got=%#v", want, got)
+	}
+
+	err = hc.Sync(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error during Sync: %#v", err)
+	}
+
+	want = []string{"http://127.0.0.1:2379", "http://127.0.0.1:4001", "http://127.0.0.1:4002", "http://127.0.0.1:4003"}
+	got = hc.Endpoints()
+	sort.Sort(sort.StringSlice(got))
+	if !reflect.DeepEqual(want, got) {
+		t.Fatalf("incorrect endpoints post-Sync: want=%#v got=%#v", want, got)
+	}
+
+	err = hc.reset([]string{"http://127.0.0.1:4009"})
+	if err != nil {
+		t.Fatalf("unexpected error during reset: %#v", err)
+	}
+
+	want = []string{"http://127.0.0.1:4009"}
+	got = hc.Endpoints()
+	if !reflect.DeepEqual(want, got) {
+		t.Fatalf("incorrect endpoints post-reset: want=%#v got=%#v", want, got)
+	}
+}
+
+func TestHTTPClusterClientSyncFail(t *testing.T) {
+	cf := newStaticHTTPClientFactory([]staticHTTPResponse{
+		{err: errors.New("fail!")},
+	})
+
+	hc := &httpClusterClient{
+		clientFactory: cf,
+		rand:          rand.New(rand.NewSource(0)),
+	}
+	err := hc.reset([]string{"http://127.0.0.1:2379"})
+	if err != nil {
+		t.Fatalf("unexpected error during setup: %#v", err)
+	}
+
+	want := []string{"http://127.0.0.1:2379"}
+	got := hc.Endpoints()
+	if !reflect.DeepEqual(want, got) {
+		t.Fatalf("incorrect endpoints: want=%#v got=%#v", want, got)
+	}
+
+	err = hc.Sync(context.Background())
+	if err == nil {
+		t.Fatalf("got nil error during Sync")
+	}
+
+	got = hc.Endpoints()
+	if !reflect.DeepEqual(want, got) {
+		t.Fatalf("incorrect endpoints after failed Sync: want=%#v got=%#v", want, got)
+	}
+}
+
+func TestHTTPClusterClientAutoSyncCancelContext(t *testing.T) {
+	cf := newStaticHTTPClientFactory([]staticHTTPResponse{
+		{
+			resp: http.Response{StatusCode: http.StatusOK, Header: http.Header{"Content-Type": []string{"application/json"}}},
+			body: []byte(`{"members":[{"id":"2745e2525fce8fe","peerURLs":["http://127.0.0.1:7003"],"name":"node3","clientURLs":["http://127.0.0.1:4003"]},{"id":"42134f434382925","peerURLs":["http://127.0.0.1:2380","http://127.0.0.1:7001"],"name":"node1","clientURLs":["http://127.0.0.1:2379","http://127.0.0.1:4001"]},{"id":"94088180e21eb87b","peerURLs":["http://127.0.0.1:7002"],"name":"node2","clientURLs":["http://127.0.0.1:4002"]}]}`),
+		},
+	})
+
+	hc := &httpClusterClient{
+		clientFactory: cf,
+		rand:          rand.New(rand.NewSource(0)),
+	}
+	err := hc.reset([]string{"http://127.0.0.1:2379"})
+	if err != nil {
+		t.Fatalf("unexpected error during setup: %#v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err = hc.AutoSync(ctx, time.Hour)
+	if err != context.Canceled {
+		t.Fatalf("incorrect error value: want=%v got=%v", context.Canceled, err)
+	}
+}
+
+func TestHTTPClusterClientAutoSyncFail(t *testing.T) {
+	cf := newStaticHTTPClientFactory([]staticHTTPResponse{
+		{err: errors.New("fail!")},
+	})
+
+	hc := &httpClusterClient{
+		clientFactory: cf,
+		rand:          rand.New(rand.NewSource(0)),
+	}
+	err := hc.reset([]string{"http://127.0.0.1:2379"})
+	if err != nil {
+		t.Fatalf("unexpected error during setup: %#v", err)
+	}
+
+	err = hc.AutoSync(context.Background(), time.Hour)
+	if err.Error() != ErrClusterUnavailable.Error() {
+		t.Fatalf("incorrect error value: want=%v got=%v", ErrClusterUnavailable, err)
+	}
+}
+
+// TestHTTPClusterClientSyncPinEndpoint tests that Sync() pins the endpoint when
+// it gets the exactly same member list as before.
+func TestHTTPClusterClientSyncPinEndpoint(t *testing.T) {
+	cf := newStaticHTTPClientFactory([]staticHTTPResponse{
+		{
+			resp: http.Response{StatusCode: http.StatusOK, Header: http.Header{"Content-Type": []string{"application/json"}}},
+			body: []byte(`{"members":[{"id":"2745e2525fce8fe","peerURLs":["http://127.0.0.1:7003"],"name":"node3","clientURLs":["http://127.0.0.1:4003"]},{"id":"42134f434382925","peerURLs":["http://127.0.0.1:2380","http://127.0.0.1:7001"],"name":"node1","clientURLs":["http://127.0.0.1:2379","http://127.0.0.1:4001"]},{"id":"94088180e21eb87b","peerURLs":["http://127.0.0.1:7002"],"name":"node2","clientURLs":["http://127.0.0.1:4002"]}]}`),
+		},
+		{
+			resp: http.Response{StatusCode: http.StatusOK, Header: http.Header{"Content-Type": []string{"application/json"}}},
+			body: []byte(`{"members":[{"id":"2745e2525fce8fe","peerURLs":["http://127.0.0.1:7003"],"name":"node3","clientURLs":["http://127.0.0.1:4003"]},{"id":"42134f434382925","peerURLs":["http://127.0.0.1:2380","http://127.0.0.1:7001"],"name":"node1","clientURLs":["http://127.0.0.1:2379","http://127.0.0.1:4001"]},{"id":"94088180e21eb87b","peerURLs":["http://127.0.0.1:7002"],"name":"node2","clientURLs":["http://127.0.0.1:4002"]}]}`),
+		},
+		{
+			resp: http.Response{StatusCode: http.StatusOK, Header: http.Header{"Content-Type": []string{"application/json"}}},
+			body: []byte(`{"members":[{"id":"2745e2525fce8fe","peerURLs":["http://127.0.0.1:7003"],"name":"node3","clientURLs":["http://127.0.0.1:4003"]},{"id":"42134f434382925","peerURLs":["http://127.0.0.1:2380","http://127.0.0.1:7001"],"name":"node1","clientURLs":["http://127.0.0.1:2379","http://127.0.0.1:4001"]},{"id":"94088180e21eb87b","peerURLs":["http://127.0.0.1:7002"],"name":"node2","clientURLs":["http://127.0.0.1:4002"]}]}`),
+		},
+	})
+
+	hc := &httpClusterClient{
+		clientFactory: cf,
+		rand:          rand.New(rand.NewSource(0)),
+	}
+	err := hc.reset([]string{"http://127.0.0.1:4003", "http://127.0.0.1:2379", "http://127.0.0.1:4001", "http://127.0.0.1:4002"})
+	if err != nil {
+		t.Fatalf("unexpected error during setup: %#v", err)
+	}
+	pinnedEndpoint := hc.endpoints[hc.pinned]
+
+	for i := 0; i < 3; i++ {
+		err = hc.Sync(context.Background())
+		if err != nil {
+			t.Fatalf("#%d: unexpected error during Sync: %#v", i, err)
+		}
+
+		if g := hc.endpoints[hc.pinned]; g != pinnedEndpoint {
+			t.Errorf("#%d: pinned endpoint = %s, want %s", i, g, pinnedEndpoint)
+		}
+	}
+}
+
+func TestHTTPClusterClientResetFail(t *testing.T) {
+	tests := [][]string{
+		// need at least one endpoint
+		{},
+
+		// urls must be valid
+		{":"},
+	}
+
+	for i, tt := range tests {
+		hc := &httpClusterClient{rand: rand.New(rand.NewSource(0))}
+		err := hc.reset(tt)
+		if err == nil {
+			t.Errorf("#%d: expected non-nil error", i)
+		}
+	}
+}
+
+func TestHTTPClusterClientResetPinRandom(t *testing.T) {
+	round := 2000
+	pinNum := 0
+	for i := 0; i < round; i++ {
+		hc := &httpClusterClient{rand: rand.New(rand.NewSource(int64(i)))}
+		err := hc.reset([]string{"http://127.0.0.1:4001", "http://127.0.0.1:4002", "http://127.0.0.1:4003"})
+		if err != nil {
+			t.Fatalf("#%d: reset error (%v)", i, err)
+		}
+		if hc.endpoints[hc.pinned].String() == "http://127.0.0.1:4001" {
+			pinNum++
+		}
+	}
+
+	min := 1.0/3.0 - 0.05
+	max := 1.0/3.0 + 0.05
+	if ratio := float64(pinNum) / float64(round); ratio > max || ratio < min {
+		t.Errorf("pinned ratio = %v, want [%v, %v]", ratio, min, max)
+	}
+}

--- a/vendor/github.com/coreos/etcd/client/cluster_error.go
+++ b/vendor/github.com/coreos/etcd/client/cluster_error.go
@@ -1,0 +1,33 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import "fmt"
+
+type ClusterError struct {
+	Errors []error
+}
+
+func (ce *ClusterError) Error() string {
+	return ErrClusterUnavailable.Error()
+}
+
+func (ce *ClusterError) Detail() string {
+	s := ""
+	for i, e := range ce.Errors {
+		s += fmt.Sprintf("error #%d: %s\n", i, e)
+	}
+	return s
+}

--- a/vendor/github.com/coreos/etcd/client/curl.go
+++ b/vendor/github.com/coreos/etcd/client/curl.go
@@ -1,0 +1,70 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+)
+
+var (
+	cURLDebug = false
+)
+
+func EnablecURLDebug() {
+	cURLDebug = true
+}
+
+func DisablecURLDebug() {
+	cURLDebug = false
+}
+
+// printcURL prints the cURL equivalent request to stderr.
+// It returns an error if the body of the request cannot
+// be read.
+// The caller MUST cancel the request if there is an error.
+func printcURL(req *http.Request) error {
+	if !cURLDebug {
+		return nil
+	}
+	var (
+		command string
+		b       []byte
+		err     error
+	)
+
+	if req.URL != nil {
+		command = fmt.Sprintf("curl -X %s %s", req.Method, req.URL.String())
+	}
+
+	if req.Body != nil {
+		b, err = ioutil.ReadAll(req.Body)
+		if err != nil {
+			return err
+		}
+		command += fmt.Sprintf(" -d %q", string(b))
+	}
+
+	fmt.Fprintf(os.Stderr, "cURL Command: %s\n", command)
+
+	// reset body
+	body := bytes.NewBuffer(b)
+	req.Body = ioutil.NopCloser(body)
+
+	return nil
+}

--- a/vendor/github.com/coreos/etcd/client/discover.go
+++ b/vendor/github.com/coreos/etcd/client/discover.go
@@ -1,0 +1,21 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+// Discoverer is an interface that wraps the Discover method.
+type Discoverer interface {
+	// Dicover looks up the etcd servers for the domain.
+	Discover(domain string) ([]string, error)
+}

--- a/vendor/github.com/coreos/etcd/client/doc.go
+++ b/vendor/github.com/coreos/etcd/client/doc.go
@@ -1,0 +1,71 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+Package client provides bindings for the etcd APIs.
+
+Create a Config and exchange it for a Client:
+
+	import (
+		"net/http"
+
+		"github.com/coreos/etcd/client"
+		"golang.org/x/net/context"
+	)
+
+	cfg := client.Config{
+		Endpoints: []string{"http://127.0.0.1:2379"},
+		Transport: DefaultTransport,
+	}
+
+	c, err := client.New(cfg)
+	if err != nil {
+		// handle error
+	}
+
+Create a KeysAPI using the Client, then use it to interact with etcd:
+
+	kAPI := client.NewKeysAPI(c)
+
+	// create a new key /foo with the value "bar"
+	_, err = kAPI.Create(context.Background(), "/foo", "bar")
+	if err != nil {
+		// handle error
+	}
+
+	// delete the newly created key only if the value is still "bar"
+	_, err = kAPI.Delete(context.Background(), "/foo", &DeleteOptions{PrevValue: "bar"})
+	if err != nil {
+		// handle error
+	}
+
+Use a custom context to set timeouts on your operations:
+
+	import "time"
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// set a new key, ignoring it's previous state
+	_, err := kAPI.Set(ctx, "/ping", "pong", nil)
+	if err != nil {
+		if err == context.DeadlineExceeded {
+			// request took longer than 5s
+		} else {
+			// handle error
+		}
+	}
+
+*/
+package client

--- a/vendor/github.com/coreos/etcd/client/fake_transport_go14_test.go
+++ b/vendor/github.com/coreos/etcd/client/fake_transport_go14_test.go
@@ -1,0 +1,41 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !go1.5
+
+package client
+
+import (
+	"errors"
+	"net/http"
+)
+
+func (t *fakeTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	select {
+	case resp := <-t.respchan:
+		return resp, nil
+	case err := <-t.errchan:
+		return nil, err
+	case <-t.startCancel:
+		select {
+		// this simulates that the request is finished before cancel effects
+		case resp := <-t.respchan:
+			return resp, nil
+		// wait on finishCancel to simulate taking some amount of
+		// time while calling CancelRequest
+		case <-t.finishCancel:
+			return nil, errors.New("cancelled")
+		}
+	}
+}

--- a/vendor/github.com/coreos/etcd/client/fake_transport_test.go
+++ b/vendor/github.com/coreos/etcd/client/fake_transport_test.go
@@ -1,0 +1,42 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build go1.5
+
+package client
+
+import (
+	"errors"
+	"net/http"
+)
+
+func (t *fakeTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	select {
+	case resp := <-t.respchan:
+		return resp, nil
+	case err := <-t.errchan:
+		return nil, err
+	case <-t.startCancel:
+	case <-req.Cancel:
+	}
+	select {
+	// this simulates that the request is finished before cancel effects
+	case resp := <-t.respchan:
+		return resp, nil
+	// wait on finishCancel to simulate taking some amount of
+	// time while calling CancelRequest
+	case <-t.finishCancel:
+		return nil, errors.New("cancelled")
+	}
+}

--- a/vendor/github.com/coreos/etcd/client/keys.go
+++ b/vendor/github.com/coreos/etcd/client/keys.go
@@ -1,0 +1,641 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/coreos/etcd/pkg/pathutil"
+	"golang.org/x/net/context"
+)
+
+const (
+	ErrorCodeKeyNotFound  = 100
+	ErrorCodeTestFailed   = 101
+	ErrorCodeNotFile      = 102
+	ErrorCodeNotDir       = 104
+	ErrorCodeNodeExist    = 105
+	ErrorCodeRootROnly    = 107
+	ErrorCodeDirNotEmpty  = 108
+	ErrorCodeUnauthorized = 110
+
+	ErrorCodePrevValueRequired = 201
+	ErrorCodeTTLNaN            = 202
+	ErrorCodeIndexNaN          = 203
+	ErrorCodeInvalidField      = 209
+	ErrorCodeInvalidForm       = 210
+
+	ErrorCodeRaftInternal = 300
+	ErrorCodeLeaderElect  = 301
+
+	ErrorCodeWatcherCleared    = 400
+	ErrorCodeEventIndexCleared = 401
+)
+
+type Error struct {
+	Code    int    `json:"errorCode"`
+	Message string `json:"message"`
+	Cause   string `json:"cause"`
+	Index   uint64 `json:"index"`
+}
+
+func (e Error) Error() string {
+	return fmt.Sprintf("%v: %v (%v) [%v]", e.Code, e.Message, e.Cause, e.Index)
+}
+
+var (
+	ErrInvalidJSON = errors.New("client: response is invalid json. The endpoint is probably not valid etcd cluster endpoint.")
+	ErrEmptyBody   = errors.New("client: response body is empty")
+)
+
+// PrevExistType is used to define an existence condition when setting
+// or deleting Nodes.
+type PrevExistType string
+
+const (
+	PrevIgnore  = PrevExistType("")
+	PrevExist   = PrevExistType("true")
+	PrevNoExist = PrevExistType("false")
+)
+
+var (
+	defaultV2KeysPrefix = "/v2/keys"
+)
+
+// NewKeysAPI builds a KeysAPI that interacts with etcd's key-value
+// API over HTTP.
+func NewKeysAPI(c Client) KeysAPI {
+	return NewKeysAPIWithPrefix(c, defaultV2KeysPrefix)
+}
+
+// NewKeysAPIWithPrefix acts like NewKeysAPI, but allows the caller
+// to provide a custom base URL path. This should only be used in
+// very rare cases.
+func NewKeysAPIWithPrefix(c Client, p string) KeysAPI {
+	return &httpKeysAPI{
+		client: c,
+		prefix: p,
+	}
+}
+
+type KeysAPI interface {
+	// Get retrieves a set of Nodes from etcd
+	Get(ctx context.Context, key string, opts *GetOptions) (*Response, error)
+
+	// Set assigns a new value to a Node identified by a given key. The caller
+	// may define a set of conditions in the SetOptions. If SetOptions.Dir=true
+	// than value is ignored.
+	Set(ctx context.Context, key, value string, opts *SetOptions) (*Response, error)
+
+	// Delete removes a Node identified by the given key, optionally destroying
+	// all of its children as well. The caller may define a set of required
+	// conditions in an DeleteOptions object.
+	Delete(ctx context.Context, key string, opts *DeleteOptions) (*Response, error)
+
+	// Create is an alias for Set w/ PrevExist=false
+	Create(ctx context.Context, key, value string) (*Response, error)
+
+	// CreateInOrder is used to atomically create in-order keys within the given directory.
+	CreateInOrder(ctx context.Context, dir, value string, opts *CreateInOrderOptions) (*Response, error)
+
+	// Update is an alias for Set w/ PrevExist=true
+	Update(ctx context.Context, key, value string) (*Response, error)
+
+	// Watcher builds a new Watcher targeted at a specific Node identified
+	// by the given key. The Watcher may be configured at creation time
+	// through a WatcherOptions object. The returned Watcher is designed
+	// to emit events that happen to a Node, and optionally to its children.
+	Watcher(key string, opts *WatcherOptions) Watcher
+}
+
+type WatcherOptions struct {
+	// AfterIndex defines the index after-which the Watcher should
+	// start emitting events. For example, if a value of 5 is
+	// provided, the first event will have an index >= 6.
+	//
+	// Setting AfterIndex to 0 (default) means that the Watcher
+	// should start watching for events starting at the current
+	// index, whatever that may be.
+	AfterIndex uint64
+
+	// Recursive specifies whether or not the Watcher should emit
+	// events that occur in children of the given keyspace. If set
+	// to false (default), events will be limited to those that
+	// occur for the exact key.
+	Recursive bool
+}
+
+type CreateInOrderOptions struct {
+	// TTL defines a period of time after-which the Node should
+	// expire and no longer exist. Values <= 0 are ignored. Given
+	// that the zero-value is ignored, TTL cannot be used to set
+	// a TTL of 0.
+	TTL time.Duration
+}
+
+type SetOptions struct {
+	// PrevValue specifies what the current value of the Node must
+	// be in order for the Set operation to succeed.
+	//
+	// Leaving this field empty means that the caller wishes to
+	// ignore the current value of the Node. This cannot be used
+	// to compare the Node's current value to an empty string.
+	//
+	// PrevValue is ignored if Dir=true
+	PrevValue string
+
+	// PrevIndex indicates what the current ModifiedIndex of the
+	// Node must be in order for the Set operation to succeed.
+	//
+	// If PrevIndex is set to 0 (default), no comparison is made.
+	PrevIndex uint64
+
+	// PrevExist specifies whether the Node must currently exist
+	// (PrevExist) or not (PrevNoExist). If the caller does not
+	// care about existence, set PrevExist to PrevIgnore, or simply
+	// leave it unset.
+	PrevExist PrevExistType
+
+	// TTL defines a period of time after-which the Node should
+	// expire and no longer exist. Values <= 0 are ignored. Given
+	// that the zero-value is ignored, TTL cannot be used to set
+	// a TTL of 0.
+	TTL time.Duration
+
+	// Dir specifies whether or not this Node should be created as a directory.
+	Dir bool
+}
+
+type GetOptions struct {
+	// Recursive defines whether or not all children of the Node
+	// should be returned.
+	Recursive bool
+
+	// Sort instructs the server whether or not to sort the Nodes.
+	// If true, the Nodes are sorted alphabetically by key in
+	// ascending order (A to z). If false (default), the Nodes will
+	// not be sorted and the ordering used should not be considered
+	// predictable.
+	Sort bool
+
+	// Quorum specifies whether it gets the latest committed value that
+	// has been applied in quorum of members, which ensures external
+	// consistency (or linearizability).
+	Quorum bool
+}
+
+type DeleteOptions struct {
+	// PrevValue specifies what the current value of the Node must
+	// be in order for the Delete operation to succeed.
+	//
+	// Leaving this field empty means that the caller wishes to
+	// ignore the current value of the Node. This cannot be used
+	// to compare the Node's current value to an empty string.
+	PrevValue string
+
+	// PrevIndex indicates what the current ModifiedIndex of the
+	// Node must be in order for the Delete operation to succeed.
+	//
+	// If PrevIndex is set to 0 (default), no comparison is made.
+	PrevIndex uint64
+
+	// Recursive defines whether or not all children of the Node
+	// should be deleted. If set to true, all children of the Node
+	// identified by the given key will be deleted. If left unset
+	// or explicitly set to false, only a single Node will be
+	// deleted.
+	Recursive bool
+
+	// Dir specifies whether or not this Node should be removed as a directory.
+	Dir bool
+}
+
+type Watcher interface {
+	// Next blocks until an etcd event occurs, then returns a Response
+	// represeting that event. The behavior of Next depends on the
+	// WatcherOptions used to construct the Watcher. Next is designed to
+	// be called repeatedly, each time blocking until a subsequent event
+	// is available.
+	//
+	// If the provided context is cancelled, Next will return a non-nil
+	// error. Any other failures encountered while waiting for the next
+	// event (connection issues, deserialization failures, etc) will
+	// also result in a non-nil error.
+	Next(context.Context) (*Response, error)
+}
+
+type Response struct {
+	// Action is the name of the operation that occurred. Possible values
+	// include get, set, delete, update, create, compareAndSwap,
+	// compareAndDelete and expire.
+	Action string `json:"action"`
+
+	// Node represents the state of the relevant etcd Node.
+	Node *Node `json:"node"`
+
+	// PrevNode represents the previous state of the Node. PrevNode is non-nil
+	// only if the Node existed before the action occurred and the action
+	// caused a change to the Node.
+	PrevNode *Node `json:"prevNode"`
+
+	// Index holds the cluster-level index at the time the Response was generated.
+	// This index is not tied to the Node(s) contained in this Response.
+	Index uint64 `json:"-"`
+}
+
+type Node struct {
+	// Key represents the unique location of this Node (e.g. "/foo/bar").
+	Key string `json:"key"`
+
+	// Dir reports whether node describes a directory.
+	Dir bool `json:"dir,omitempty"`
+
+	// Value is the current data stored on this Node. If this Node
+	// is a directory, Value will be empty.
+	Value string `json:"value"`
+
+	// Nodes holds the children of this Node, only if this Node is a directory.
+	// This slice of will be arbitrarily deep (children, grandchildren, great-
+	// grandchildren, etc.) if a recursive Get or Watch request were made.
+	Nodes []*Node `json:"nodes"`
+
+	// CreatedIndex is the etcd index at-which this Node was created.
+	CreatedIndex uint64 `json:"createdIndex"`
+
+	// ModifiedIndex is the etcd index at-which this Node was last modified.
+	ModifiedIndex uint64 `json:"modifiedIndex"`
+
+	// Expiration is the server side expiration time of the key.
+	Expiration *time.Time `json:"expiration,omitempty"`
+
+	// TTL is the time to live of the key in second.
+	TTL int64 `json:"ttl,omitempty"`
+}
+
+func (n *Node) String() string {
+	return fmt.Sprintf("{Key: %s, CreatedIndex: %d, ModifiedIndex: %d, TTL: %d}", n.Key, n.CreatedIndex, n.ModifiedIndex, n.TTL)
+}
+
+// TTLDuration returns the Node's TTL as a time.Duration object
+func (n *Node) TTLDuration() time.Duration {
+	return time.Duration(n.TTL) * time.Second
+}
+
+type httpKeysAPI struct {
+	client httpClient
+	prefix string
+}
+
+func (k *httpKeysAPI) Set(ctx context.Context, key, val string, opts *SetOptions) (*Response, error) {
+	act := &setAction{
+		Prefix: k.prefix,
+		Key:    key,
+		Value:  val,
+	}
+
+	if opts != nil {
+		act.PrevValue = opts.PrevValue
+		act.PrevIndex = opts.PrevIndex
+		act.PrevExist = opts.PrevExist
+		act.TTL = opts.TTL
+		act.Dir = opts.Dir
+	}
+
+	resp, body, err := k.client.Do(ctx, act)
+	if err != nil {
+		return nil, err
+	}
+
+	return unmarshalHTTPResponse(resp.StatusCode, resp.Header, body)
+}
+
+func (k *httpKeysAPI) Create(ctx context.Context, key, val string) (*Response, error) {
+	return k.Set(ctx, key, val, &SetOptions{PrevExist: PrevNoExist})
+}
+
+func (k *httpKeysAPI) CreateInOrder(ctx context.Context, dir, val string, opts *CreateInOrderOptions) (*Response, error) {
+	act := &createInOrderAction{
+		Prefix: k.prefix,
+		Dir:    dir,
+		Value:  val,
+	}
+
+	if opts != nil {
+		act.TTL = opts.TTL
+	}
+
+	resp, body, err := k.client.Do(ctx, act)
+	if err != nil {
+		return nil, err
+	}
+
+	return unmarshalHTTPResponse(resp.StatusCode, resp.Header, body)
+}
+
+func (k *httpKeysAPI) Update(ctx context.Context, key, val string) (*Response, error) {
+	return k.Set(ctx, key, val, &SetOptions{PrevExist: PrevExist})
+}
+
+func (k *httpKeysAPI) Delete(ctx context.Context, key string, opts *DeleteOptions) (*Response, error) {
+	act := &deleteAction{
+		Prefix: k.prefix,
+		Key:    key,
+	}
+
+	if opts != nil {
+		act.PrevValue = opts.PrevValue
+		act.PrevIndex = opts.PrevIndex
+		act.Dir = opts.Dir
+		act.Recursive = opts.Recursive
+	}
+
+	resp, body, err := k.client.Do(ctx, act)
+	if err != nil {
+		return nil, err
+	}
+
+	return unmarshalHTTPResponse(resp.StatusCode, resp.Header, body)
+}
+
+func (k *httpKeysAPI) Get(ctx context.Context, key string, opts *GetOptions) (*Response, error) {
+	act := &getAction{
+		Prefix: k.prefix,
+		Key:    key,
+	}
+
+	if opts != nil {
+		act.Recursive = opts.Recursive
+		act.Sorted = opts.Sort
+		act.Quorum = opts.Quorum
+	}
+
+	resp, body, err := k.client.Do(ctx, act)
+	if err != nil {
+		return nil, err
+	}
+
+	return unmarshalHTTPResponse(resp.StatusCode, resp.Header, body)
+}
+
+func (k *httpKeysAPI) Watcher(key string, opts *WatcherOptions) Watcher {
+	act := waitAction{
+		Prefix: k.prefix,
+		Key:    key,
+	}
+
+	if opts != nil {
+		act.Recursive = opts.Recursive
+		if opts.AfterIndex > 0 {
+			act.WaitIndex = opts.AfterIndex + 1
+		}
+	}
+
+	return &httpWatcher{
+		client:   k.client,
+		nextWait: act,
+	}
+}
+
+type httpWatcher struct {
+	client   httpClient
+	nextWait waitAction
+}
+
+func (hw *httpWatcher) Next(ctx context.Context) (*Response, error) {
+	for {
+		httpresp, body, err := hw.client.Do(ctx, &hw.nextWait)
+		if err != nil {
+			return nil, err
+		}
+
+		resp, err := unmarshalHTTPResponse(httpresp.StatusCode, httpresp.Header, body)
+		if err != nil {
+			if err == ErrEmptyBody {
+				continue
+			}
+			return nil, err
+		}
+
+		hw.nextWait.WaitIndex = resp.Node.ModifiedIndex + 1
+		return resp, nil
+	}
+}
+
+// v2KeysURL forms a URL representing the location of a key.
+// The endpoint argument represents the base URL of an etcd
+// server. The prefix is the path needed to route from the
+// provided endpoint's path to the root of the keys API
+// (typically "/v2/keys").
+func v2KeysURL(ep url.URL, prefix, key string) *url.URL {
+	// We concatenate all parts together manually. We cannot use
+	// path.Join because it does not reserve trailing slash.
+	// We call CanonicalURLPath to further cleanup the path.
+	if prefix != "" && prefix[0] != '/' {
+		prefix = "/" + prefix
+	}
+	if key != "" && key[0] != '/' {
+		key = "/" + key
+	}
+	ep.Path = pathutil.CanonicalURLPath(ep.Path + prefix + key)
+	return &ep
+}
+
+type getAction struct {
+	Prefix    string
+	Key       string
+	Recursive bool
+	Sorted    bool
+	Quorum    bool
+}
+
+func (g *getAction) HTTPRequest(ep url.URL) *http.Request {
+	u := v2KeysURL(ep, g.Prefix, g.Key)
+
+	params := u.Query()
+	params.Set("recursive", strconv.FormatBool(g.Recursive))
+	params.Set("sorted", strconv.FormatBool(g.Sorted))
+	params.Set("quorum", strconv.FormatBool(g.Quorum))
+	u.RawQuery = params.Encode()
+
+	req, _ := http.NewRequest("GET", u.String(), nil)
+	return req
+}
+
+type waitAction struct {
+	Prefix    string
+	Key       string
+	WaitIndex uint64
+	Recursive bool
+}
+
+func (w *waitAction) HTTPRequest(ep url.URL) *http.Request {
+	u := v2KeysURL(ep, w.Prefix, w.Key)
+
+	params := u.Query()
+	params.Set("wait", "true")
+	params.Set("waitIndex", strconv.FormatUint(w.WaitIndex, 10))
+	params.Set("recursive", strconv.FormatBool(w.Recursive))
+	u.RawQuery = params.Encode()
+
+	req, _ := http.NewRequest("GET", u.String(), nil)
+	return req
+}
+
+type setAction struct {
+	Prefix    string
+	Key       string
+	Value     string
+	PrevValue string
+	PrevIndex uint64
+	PrevExist PrevExistType
+	TTL       time.Duration
+	Dir       bool
+}
+
+func (a *setAction) HTTPRequest(ep url.URL) *http.Request {
+	u := v2KeysURL(ep, a.Prefix, a.Key)
+
+	params := u.Query()
+	form := url.Values{}
+
+	// we're either creating a directory or setting a key
+	if a.Dir {
+		params.Set("dir", strconv.FormatBool(a.Dir))
+	} else {
+		// These options are only valid for setting a key
+		if a.PrevValue != "" {
+			params.Set("prevValue", a.PrevValue)
+		}
+		form.Add("value", a.Value)
+	}
+
+	// Options which apply to both setting a key and creating a dir
+	if a.PrevIndex != 0 {
+		params.Set("prevIndex", strconv.FormatUint(a.PrevIndex, 10))
+	}
+	if a.PrevExist != PrevIgnore {
+		params.Set("prevExist", string(a.PrevExist))
+	}
+	if a.TTL > 0 {
+		form.Add("ttl", strconv.FormatUint(uint64(a.TTL.Seconds()), 10))
+	}
+
+	u.RawQuery = params.Encode()
+	body := strings.NewReader(form.Encode())
+
+	req, _ := http.NewRequest("PUT", u.String(), body)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	return req
+}
+
+type deleteAction struct {
+	Prefix    string
+	Key       string
+	PrevValue string
+	PrevIndex uint64
+	Dir       bool
+	Recursive bool
+}
+
+func (a *deleteAction) HTTPRequest(ep url.URL) *http.Request {
+	u := v2KeysURL(ep, a.Prefix, a.Key)
+
+	params := u.Query()
+	if a.PrevValue != "" {
+		params.Set("prevValue", a.PrevValue)
+	}
+	if a.PrevIndex != 0 {
+		params.Set("prevIndex", strconv.FormatUint(a.PrevIndex, 10))
+	}
+	if a.Dir {
+		params.Set("dir", "true")
+	}
+	if a.Recursive {
+		params.Set("recursive", "true")
+	}
+	u.RawQuery = params.Encode()
+
+	req, _ := http.NewRequest("DELETE", u.String(), nil)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	return req
+}
+
+type createInOrderAction struct {
+	Prefix string
+	Dir    string
+	Value  string
+	TTL    time.Duration
+}
+
+func (a *createInOrderAction) HTTPRequest(ep url.URL) *http.Request {
+	u := v2KeysURL(ep, a.Prefix, a.Dir)
+
+	form := url.Values{}
+	form.Add("value", a.Value)
+	if a.TTL > 0 {
+		form.Add("ttl", strconv.FormatUint(uint64(a.TTL.Seconds()), 10))
+	}
+	body := strings.NewReader(form.Encode())
+
+	req, _ := http.NewRequest("POST", u.String(), body)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	return req
+}
+
+func unmarshalHTTPResponse(code int, header http.Header, body []byte) (res *Response, err error) {
+	switch code {
+	case http.StatusOK, http.StatusCreated:
+		if len(body) == 0 {
+			return nil, ErrEmptyBody
+		}
+		res, err = unmarshalSuccessfulKeysResponse(header, body)
+	default:
+		err = unmarshalFailedKeysResponse(body)
+	}
+
+	return
+}
+
+func unmarshalSuccessfulKeysResponse(header http.Header, body []byte) (*Response, error) {
+	var res Response
+	err := json.Unmarshal(body, &res)
+	if err != nil {
+		return nil, ErrInvalidJSON
+	}
+	if header.Get("X-Etcd-Index") != "" {
+		res.Index, err = strconv.ParseUint(header.Get("X-Etcd-Index"), 10, 64)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return &res, nil
+}
+
+func unmarshalFailedKeysResponse(body []byte) error {
+	var etcdErr Error
+	if err := json.Unmarshal(body, &etcdErr); err != nil {
+		return ErrInvalidJSON
+	}
+	return etcdErr
+}

--- a/vendor/github.com/coreos/etcd/client/keys_test.go
+++ b/vendor/github.com/coreos/etcd/client/keys_test.go
@@ -1,0 +1,1407 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"reflect"
+	"testing"
+	"time"
+
+	"golang.org/x/net/context"
+)
+
+func TestV2KeysURLHelper(t *testing.T) {
+	tests := []struct {
+		endpoint url.URL
+		prefix   string
+		key      string
+		want     url.URL
+	}{
+		// key is empty, no problem
+		{
+			endpoint: url.URL{Scheme: "http", Host: "example.com", Path: "/v2/keys"},
+			prefix:   "",
+			key:      "",
+			want:     url.URL{Scheme: "http", Host: "example.com", Path: "/v2/keys"},
+		},
+
+		// key is joined to path
+		{
+			endpoint: url.URL{Scheme: "http", Host: "example.com", Path: "/v2/keys"},
+			prefix:   "",
+			key:      "/foo/bar",
+			want:     url.URL{Scheme: "http", Host: "example.com", Path: "/v2/keys/foo/bar"},
+		},
+
+		// key is joined to path when path is empty
+		{
+			endpoint: url.URL{Scheme: "http", Host: "example.com", Path: ""},
+			prefix:   "",
+			key:      "/foo/bar",
+			want:     url.URL{Scheme: "http", Host: "example.com", Path: "/foo/bar"},
+		},
+
+		// Host field carries through with port
+		{
+			endpoint: url.URL{Scheme: "http", Host: "example.com:8080", Path: "/v2/keys"},
+			prefix:   "",
+			key:      "",
+			want:     url.URL{Scheme: "http", Host: "example.com:8080", Path: "/v2/keys"},
+		},
+
+		// Scheme carries through
+		{
+			endpoint: url.URL{Scheme: "https", Host: "example.com", Path: "/v2/keys"},
+			prefix:   "",
+			key:      "",
+			want:     url.URL{Scheme: "https", Host: "example.com", Path: "/v2/keys"},
+		},
+		// Prefix is applied
+		{
+			endpoint: url.URL{Scheme: "https", Host: "example.com", Path: "/foo"},
+			prefix:   "/bar",
+			key:      "/baz",
+			want:     url.URL{Scheme: "https", Host: "example.com", Path: "/foo/bar/baz"},
+		},
+		// Prefix is joined to path
+		{
+			endpoint: url.URL{Scheme: "https", Host: "example.com", Path: "/foo"},
+			prefix:   "/bar",
+			key:      "",
+			want:     url.URL{Scheme: "https", Host: "example.com", Path: "/foo/bar"},
+		},
+		// Keep trailing slash
+		{
+			endpoint: url.URL{Scheme: "https", Host: "example.com", Path: "/foo"},
+			prefix:   "/bar",
+			key:      "/baz/",
+			want:     url.URL{Scheme: "https", Host: "example.com", Path: "/foo/bar/baz/"},
+		},
+	}
+
+	for i, tt := range tests {
+		got := v2KeysURL(tt.endpoint, tt.prefix, tt.key)
+		if tt.want != *got {
+			t.Errorf("#%d: want=%#v, got=%#v", i, tt.want, *got)
+		}
+	}
+}
+
+func TestGetAction(t *testing.T) {
+	ep := url.URL{Scheme: "http", Host: "example.com", Path: "/v2/keys"}
+	baseWantURL := &url.URL{
+		Scheme: "http",
+		Host:   "example.com",
+		Path:   "/v2/keys/foo/bar",
+	}
+	wantHeader := http.Header{}
+
+	tests := []struct {
+		recursive bool
+		sorted    bool
+		quorum    bool
+		wantQuery string
+	}{
+		{
+			recursive: false,
+			sorted:    false,
+			quorum:    false,
+			wantQuery: "quorum=false&recursive=false&sorted=false",
+		},
+		{
+			recursive: true,
+			sorted:    false,
+			quorum:    false,
+			wantQuery: "quorum=false&recursive=true&sorted=false",
+		},
+		{
+			recursive: false,
+			sorted:    true,
+			quorum:    false,
+			wantQuery: "quorum=false&recursive=false&sorted=true",
+		},
+		{
+			recursive: true,
+			sorted:    true,
+			quorum:    false,
+			wantQuery: "quorum=false&recursive=true&sorted=true",
+		},
+		{
+			recursive: false,
+			sorted:    false,
+			quorum:    true,
+			wantQuery: "quorum=true&recursive=false&sorted=false",
+		},
+	}
+
+	for i, tt := range tests {
+		f := getAction{
+			Key:       "/foo/bar",
+			Recursive: tt.recursive,
+			Sorted:    tt.sorted,
+			Quorum:    tt.quorum,
+		}
+		got := *f.HTTPRequest(ep)
+
+		wantURL := baseWantURL
+		wantURL.RawQuery = tt.wantQuery
+
+		err := assertRequest(got, "GET", wantURL, wantHeader, nil)
+		if err != nil {
+			t.Errorf("#%d: %v", i, err)
+		}
+	}
+}
+
+func TestWaitAction(t *testing.T) {
+	ep := url.URL{Scheme: "http", Host: "example.com", Path: "/v2/keys"}
+	baseWantURL := &url.URL{
+		Scheme: "http",
+		Host:   "example.com",
+		Path:   "/v2/keys/foo/bar",
+	}
+	wantHeader := http.Header{}
+
+	tests := []struct {
+		waitIndex uint64
+		recursive bool
+		wantQuery string
+	}{
+		{
+			recursive: false,
+			waitIndex: uint64(0),
+			wantQuery: "recursive=false&wait=true&waitIndex=0",
+		},
+		{
+			recursive: false,
+			waitIndex: uint64(12),
+			wantQuery: "recursive=false&wait=true&waitIndex=12",
+		},
+		{
+			recursive: true,
+			waitIndex: uint64(12),
+			wantQuery: "recursive=true&wait=true&waitIndex=12",
+		},
+	}
+
+	for i, tt := range tests {
+		f := waitAction{
+			Key:       "/foo/bar",
+			WaitIndex: tt.waitIndex,
+			Recursive: tt.recursive,
+		}
+		got := *f.HTTPRequest(ep)
+
+		wantURL := baseWantURL
+		wantURL.RawQuery = tt.wantQuery
+
+		err := assertRequest(got, "GET", wantURL, wantHeader, nil)
+		if err != nil {
+			t.Errorf("#%d: unexpected error: %#v", i, err)
+		}
+	}
+}
+
+func TestSetAction(t *testing.T) {
+	wantHeader := http.Header(map[string][]string{
+		"Content-Type": {"application/x-www-form-urlencoded"},
+	})
+
+	tests := []struct {
+		act      setAction
+		wantURL  string
+		wantBody string
+	}{
+		// default prefix
+		{
+			act: setAction{
+				Prefix: defaultV2KeysPrefix,
+				Key:    "foo",
+			},
+			wantURL:  "http://example.com/v2/keys/foo",
+			wantBody: "value=",
+		},
+
+		// non-default prefix
+		{
+			act: setAction{
+				Prefix: "/pfx",
+				Key:    "foo",
+			},
+			wantURL:  "http://example.com/pfx/foo",
+			wantBody: "value=",
+		},
+
+		// no prefix
+		{
+			act: setAction{
+				Key: "foo",
+			},
+			wantURL:  "http://example.com/foo",
+			wantBody: "value=",
+		},
+
+		// Key with path separators
+		{
+			act: setAction{
+				Prefix: defaultV2KeysPrefix,
+				Key:    "foo/bar/baz",
+			},
+			wantURL:  "http://example.com/v2/keys/foo/bar/baz",
+			wantBody: "value=",
+		},
+
+		// Key with leading slash, Prefix with trailing slash
+		{
+			act: setAction{
+				Prefix: "/foo/",
+				Key:    "/bar",
+			},
+			wantURL:  "http://example.com/foo/bar",
+			wantBody: "value=",
+		},
+
+		// Key with trailing slash
+		{
+			act: setAction{
+				Key: "/foo/",
+			},
+			wantURL:  "http://example.com/foo/",
+			wantBody: "value=",
+		},
+
+		// Value is set
+		{
+			act: setAction{
+				Key:   "foo",
+				Value: "baz",
+			},
+			wantURL:  "http://example.com/foo",
+			wantBody: "value=baz",
+		},
+
+		// PrevExist set, but still ignored
+		{
+			act: setAction{
+				Key:       "foo",
+				PrevExist: PrevIgnore,
+			},
+			wantURL:  "http://example.com/foo",
+			wantBody: "value=",
+		},
+
+		// PrevExist set to true
+		{
+			act: setAction{
+				Key:       "foo",
+				PrevExist: PrevExist,
+			},
+			wantURL:  "http://example.com/foo?prevExist=true",
+			wantBody: "value=",
+		},
+
+		// PrevExist set to false
+		{
+			act: setAction{
+				Key:       "foo",
+				PrevExist: PrevNoExist,
+			},
+			wantURL:  "http://example.com/foo?prevExist=false",
+			wantBody: "value=",
+		},
+
+		// PrevValue is urlencoded
+		{
+			act: setAction{
+				Key:       "foo",
+				PrevValue: "bar baz",
+			},
+			wantURL:  "http://example.com/foo?prevValue=bar+baz",
+			wantBody: "value=",
+		},
+
+		// PrevIndex is set
+		{
+			act: setAction{
+				Key:       "foo",
+				PrevIndex: uint64(12),
+			},
+			wantURL:  "http://example.com/foo?prevIndex=12",
+			wantBody: "value=",
+		},
+
+		// TTL is set
+		{
+			act: setAction{
+				Key: "foo",
+				TTL: 3 * time.Minute,
+			},
+			wantURL:  "http://example.com/foo",
+			wantBody: "ttl=180&value=",
+		},
+		// Dir is set
+		{
+			act: setAction{
+				Key: "foo",
+				Dir: true,
+			},
+			wantURL:  "http://example.com/foo?dir=true",
+			wantBody: "",
+		},
+		// Dir is set with a value
+		{
+			act: setAction{
+				Key:   "foo",
+				Value: "bar",
+				Dir:   true,
+			},
+			wantURL:  "http://example.com/foo?dir=true",
+			wantBody: "",
+		},
+		// Dir is set with PrevExist set to true
+		{
+			act: setAction{
+				Key:       "foo",
+				PrevExist: PrevExist,
+				Dir:       true,
+			},
+			wantURL:  "http://example.com/foo?dir=true&prevExist=true",
+			wantBody: "",
+		},
+		// Dir is set with PrevValue
+		{
+			act: setAction{
+				Key:       "foo",
+				PrevValue: "bar",
+				Dir:       true,
+			},
+			wantURL:  "http://example.com/foo?dir=true",
+			wantBody: "",
+		},
+	}
+
+	for i, tt := range tests {
+		u, err := url.Parse(tt.wantURL)
+		if err != nil {
+			t.Errorf("#%d: unable to use wantURL fixture: %v", i, err)
+		}
+
+		got := tt.act.HTTPRequest(url.URL{Scheme: "http", Host: "example.com"})
+		if err := assertRequest(*got, "PUT", u, wantHeader, []byte(tt.wantBody)); err != nil {
+			t.Errorf("#%d: %v", i, err)
+		}
+	}
+}
+
+func TestCreateInOrderAction(t *testing.T) {
+	wantHeader := http.Header(map[string][]string{
+		"Content-Type": {"application/x-www-form-urlencoded"},
+	})
+
+	tests := []struct {
+		act      createInOrderAction
+		wantURL  string
+		wantBody string
+	}{
+		// default prefix
+		{
+			act: createInOrderAction{
+				Prefix: defaultV2KeysPrefix,
+				Dir:    "foo",
+			},
+			wantURL:  "http://example.com/v2/keys/foo",
+			wantBody: "value=",
+		},
+
+		// non-default prefix
+		{
+			act: createInOrderAction{
+				Prefix: "/pfx",
+				Dir:    "foo",
+			},
+			wantURL:  "http://example.com/pfx/foo",
+			wantBody: "value=",
+		},
+
+		// no prefix
+		{
+			act: createInOrderAction{
+				Dir: "foo",
+			},
+			wantURL:  "http://example.com/foo",
+			wantBody: "value=",
+		},
+
+		// Key with path separators
+		{
+			act: createInOrderAction{
+				Prefix: defaultV2KeysPrefix,
+				Dir:    "foo/bar/baz",
+			},
+			wantURL:  "http://example.com/v2/keys/foo/bar/baz",
+			wantBody: "value=",
+		},
+
+		// Key with leading slash, Prefix with trailing slash
+		{
+			act: createInOrderAction{
+				Prefix: "/foo/",
+				Dir:    "/bar",
+			},
+			wantURL:  "http://example.com/foo/bar",
+			wantBody: "value=",
+		},
+
+		// Key with trailing slash
+		{
+			act: createInOrderAction{
+				Dir: "/foo/",
+			},
+			wantURL:  "http://example.com/foo/",
+			wantBody: "value=",
+		},
+
+		// Value is set
+		{
+			act: createInOrderAction{
+				Dir:   "foo",
+				Value: "baz",
+			},
+			wantURL:  "http://example.com/foo",
+			wantBody: "value=baz",
+		},
+		// TTL is set
+		{
+			act: createInOrderAction{
+				Dir: "foo",
+				TTL: 3 * time.Minute,
+			},
+			wantURL:  "http://example.com/foo",
+			wantBody: "ttl=180&value=",
+		},
+	}
+
+	for i, tt := range tests {
+		u, err := url.Parse(tt.wantURL)
+		if err != nil {
+			t.Errorf("#%d: unable to use wantURL fixture: %v", i, err)
+		}
+
+		got := tt.act.HTTPRequest(url.URL{Scheme: "http", Host: "example.com"})
+		if err := assertRequest(*got, "POST", u, wantHeader, []byte(tt.wantBody)); err != nil {
+			t.Errorf("#%d: %v", i, err)
+		}
+	}
+}
+
+func TestDeleteAction(t *testing.T) {
+	wantHeader := http.Header(map[string][]string{
+		"Content-Type": {"application/x-www-form-urlencoded"},
+	})
+
+	tests := []struct {
+		act     deleteAction
+		wantURL string
+	}{
+		// default prefix
+		{
+			act: deleteAction{
+				Prefix: defaultV2KeysPrefix,
+				Key:    "foo",
+			},
+			wantURL: "http://example.com/v2/keys/foo",
+		},
+
+		// non-default prefix
+		{
+			act: deleteAction{
+				Prefix: "/pfx",
+				Key:    "foo",
+			},
+			wantURL: "http://example.com/pfx/foo",
+		},
+
+		// no prefix
+		{
+			act: deleteAction{
+				Key: "foo",
+			},
+			wantURL: "http://example.com/foo",
+		},
+
+		// Key with path separators
+		{
+			act: deleteAction{
+				Prefix: defaultV2KeysPrefix,
+				Key:    "foo/bar/baz",
+			},
+			wantURL: "http://example.com/v2/keys/foo/bar/baz",
+		},
+
+		// Key with leading slash, Prefix with trailing slash
+		{
+			act: deleteAction{
+				Prefix: "/foo/",
+				Key:    "/bar",
+			},
+			wantURL: "http://example.com/foo/bar",
+		},
+
+		// Key with trailing slash
+		{
+			act: deleteAction{
+				Key: "/foo/",
+			},
+			wantURL: "http://example.com/foo/",
+		},
+
+		// Recursive set to true
+		{
+			act: deleteAction{
+				Key:       "foo",
+				Recursive: true,
+			},
+			wantURL: "http://example.com/foo?recursive=true",
+		},
+
+		// PrevValue is urlencoded
+		{
+			act: deleteAction{
+				Key:       "foo",
+				PrevValue: "bar baz",
+			},
+			wantURL: "http://example.com/foo?prevValue=bar+baz",
+		},
+
+		// PrevIndex is set
+		{
+			act: deleteAction{
+				Key:       "foo",
+				PrevIndex: uint64(12),
+			},
+			wantURL: "http://example.com/foo?prevIndex=12",
+		},
+	}
+
+	for i, tt := range tests {
+		u, err := url.Parse(tt.wantURL)
+		if err != nil {
+			t.Errorf("#%d: unable to use wantURL fixture: %v", i, err)
+		}
+
+		got := tt.act.HTTPRequest(url.URL{Scheme: "http", Host: "example.com"})
+		if err := assertRequest(*got, "DELETE", u, wantHeader, nil); err != nil {
+			t.Errorf("#%d: %v", i, err)
+		}
+	}
+}
+
+func assertRequest(got http.Request, wantMethod string, wantURL *url.URL, wantHeader http.Header, wantBody []byte) error {
+	if wantMethod != got.Method {
+		return fmt.Errorf("want.Method=%#v got.Method=%#v", wantMethod, got.Method)
+	}
+
+	if !reflect.DeepEqual(wantURL, got.URL) {
+		return fmt.Errorf("want.URL=%#v got.URL=%#v", wantURL, got.URL)
+	}
+
+	if !reflect.DeepEqual(wantHeader, got.Header) {
+		return fmt.Errorf("want.Header=%#v got.Header=%#v", wantHeader, got.Header)
+	}
+
+	if got.Body == nil {
+		if wantBody != nil {
+			return fmt.Errorf("want.Body=%v got.Body=%v", wantBody, got.Body)
+		}
+	} else {
+		if wantBody == nil {
+			return fmt.Errorf("want.Body=%v got.Body=%s", wantBody, got.Body)
+		} else {
+			gotBytes, err := ioutil.ReadAll(got.Body)
+			if err != nil {
+				return err
+			}
+
+			if !reflect.DeepEqual(wantBody, gotBytes) {
+				return fmt.Errorf("want.Body=%s got.Body=%s", wantBody, gotBytes)
+			}
+		}
+	}
+
+	return nil
+}
+
+func TestUnmarshalSuccessfulResponse(t *testing.T) {
+	var expiration time.Time
+	expiration.UnmarshalText([]byte("2015-04-07T04:40:23.044979686Z"))
+
+	tests := []struct {
+		hdr     string
+		body    string
+		wantRes *Response
+		wantErr bool
+	}{
+		// Neither PrevNode or Node
+		{
+			hdr:     "1",
+			body:    `{"action":"delete"}`,
+			wantRes: &Response{Action: "delete", Index: 1},
+			wantErr: false,
+		},
+
+		// PrevNode
+		{
+			hdr:  "15",
+			body: `{"action":"delete", "prevNode": {"key": "/foo", "value": "bar", "modifiedIndex": 12, "createdIndex": 10}}`,
+			wantRes: &Response{
+				Action: "delete",
+				Index:  15,
+				Node:   nil,
+				PrevNode: &Node{
+					Key:           "/foo",
+					Value:         "bar",
+					ModifiedIndex: 12,
+					CreatedIndex:  10,
+				},
+			},
+			wantErr: false,
+		},
+
+		// Node
+		{
+			hdr:  "15",
+			body: `{"action":"get", "node": {"key": "/foo", "value": "bar", "modifiedIndex": 12, "createdIndex": 10, "ttl": 10, "expiration": "2015-04-07T04:40:23.044979686Z"}}`,
+			wantRes: &Response{
+				Action: "get",
+				Index:  15,
+				Node: &Node{
+					Key:           "/foo",
+					Value:         "bar",
+					ModifiedIndex: 12,
+					CreatedIndex:  10,
+					TTL:           10,
+					Expiration:    &expiration,
+				},
+				PrevNode: nil,
+			},
+			wantErr: false,
+		},
+
+		// Node Dir
+		{
+			hdr:  "15",
+			body: `{"action":"get", "node": {"key": "/foo", "dir": true, "modifiedIndex": 12, "createdIndex": 10}}`,
+			wantRes: &Response{
+				Action: "get",
+				Index:  15,
+				Node: &Node{
+					Key:           "/foo",
+					Dir:           true,
+					ModifiedIndex: 12,
+					CreatedIndex:  10,
+				},
+				PrevNode: nil,
+			},
+			wantErr: false,
+		},
+
+		// PrevNode and Node
+		{
+			hdr:  "15",
+			body: `{"action":"update", "prevNode": {"key": "/foo", "value": "baz", "modifiedIndex": 10, "createdIndex": 10}, "node": {"key": "/foo", "value": "bar", "modifiedIndex": 12, "createdIndex": 10}}`,
+			wantRes: &Response{
+				Action: "update",
+				Index:  15,
+				PrevNode: &Node{
+					Key:           "/foo",
+					Value:         "baz",
+					ModifiedIndex: 10,
+					CreatedIndex:  10,
+				},
+				Node: &Node{
+					Key:           "/foo",
+					Value:         "bar",
+					ModifiedIndex: 12,
+					CreatedIndex:  10,
+				},
+			},
+			wantErr: false,
+		},
+
+		// Garbage in body
+		{
+			hdr:     "",
+			body:    `garbage`,
+			wantRes: nil,
+			wantErr: true,
+		},
+
+		// non-integer index
+		{
+			hdr:     "poo",
+			body:    `{}`,
+			wantRes: nil,
+			wantErr: true,
+		},
+	}
+
+	for i, tt := range tests {
+		h := make(http.Header)
+		h.Add("X-Etcd-Index", tt.hdr)
+		res, err := unmarshalSuccessfulKeysResponse(h, []byte(tt.body))
+		if tt.wantErr != (err != nil) {
+			t.Errorf("#%d: wantErr=%t, err=%v", i, tt.wantErr, err)
+		}
+
+		if (res == nil) != (tt.wantRes == nil) {
+			t.Errorf("#%d: received res=%#v, but expected res=%#v", i, res, tt.wantRes)
+			continue
+		} else if tt.wantRes == nil {
+			// expected and successfully got nil response
+			continue
+		}
+
+		if res.Action != tt.wantRes.Action {
+			t.Errorf("#%d: Action=%s, expected %s", i, res.Action, tt.wantRes.Action)
+		}
+		if res.Index != tt.wantRes.Index {
+			t.Errorf("#%d: Index=%d, expected %d", i, res.Index, tt.wantRes.Index)
+		}
+		if !reflect.DeepEqual(res.Node, tt.wantRes.Node) {
+			t.Errorf("#%d: Node=%v, expected %v", i, res.Node, tt.wantRes.Node)
+		}
+	}
+}
+
+func TestUnmarshalFailedKeysResponse(t *testing.T) {
+	body := []byte(`{"errorCode":100,"message":"Key not found","cause":"/foo","index":18}`)
+
+	wantErr := Error{
+		Code:    100,
+		Message: "Key not found",
+		Cause:   "/foo",
+		Index:   uint64(18),
+	}
+
+	gotErr := unmarshalFailedKeysResponse(body)
+	if !reflect.DeepEqual(wantErr, gotErr) {
+		t.Errorf("unexpected error: want=%#v got=%#v", wantErr, gotErr)
+	}
+}
+
+func TestUnmarshalFailedKeysResponseBadJSON(t *testing.T) {
+	err := unmarshalFailedKeysResponse([]byte(`{"er`))
+	if err == nil {
+		t.Errorf("got nil error")
+	} else if _, ok := err.(Error); ok {
+		t.Errorf("error is of incorrect type *Error: %#v", err)
+	}
+}
+
+func TestHTTPWatcherNextWaitAction(t *testing.T) {
+	initAction := waitAction{
+		Prefix:    "/pants",
+		Key:       "/foo/bar",
+		Recursive: true,
+		WaitIndex: 19,
+	}
+
+	client := &actionAssertingHTTPClient{
+		t:   t,
+		act: &initAction,
+		resp: http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"X-Etcd-Index": []string{"42"}},
+		},
+		body: []byte(`{"action":"update","node":{"key":"/pants/foo/bar/baz","value":"snarf","modifiedIndex":21,"createdIndex":19},"prevNode":{"key":"/pants/foo/bar/baz","value":"snazz","modifiedIndex":20,"createdIndex":19}}`),
+	}
+
+	wantResponse := &Response{
+		Action:   "update",
+		Node:     &Node{Key: "/pants/foo/bar/baz", Value: "snarf", CreatedIndex: uint64(19), ModifiedIndex: uint64(21)},
+		PrevNode: &Node{Key: "/pants/foo/bar/baz", Value: "snazz", CreatedIndex: uint64(19), ModifiedIndex: uint64(20)},
+		Index:    uint64(42),
+	}
+
+	wantNextWait := waitAction{
+		Prefix:    "/pants",
+		Key:       "/foo/bar",
+		Recursive: true,
+		WaitIndex: 22,
+	}
+
+	watcher := &httpWatcher{
+		client:   client,
+		nextWait: initAction,
+	}
+
+	resp, err := watcher.Next(context.Background())
+	if err != nil {
+		t.Errorf("non-nil error: %#v", err)
+	}
+
+	if !reflect.DeepEqual(wantResponse, resp) {
+		t.Errorf("received incorrect Response: want=%#v got=%#v", wantResponse, resp)
+	}
+
+	if !reflect.DeepEqual(wantNextWait, watcher.nextWait) {
+		t.Errorf("nextWait incorrect: want=%#v got=%#v", wantNextWait, watcher.nextWait)
+	}
+}
+
+func TestHTTPWatcherNextFail(t *testing.T) {
+	tests := []httpClient{
+		// generic HTTP client failure
+		&staticHTTPClient{
+			err: errors.New("fail!"),
+		},
+
+		// unusable status code
+		&staticHTTPClient{
+			resp: http.Response{
+				StatusCode: http.StatusTeapot,
+			},
+		},
+
+		// etcd Error response
+		&staticHTTPClient{
+			resp: http.Response{
+				StatusCode: http.StatusNotFound,
+			},
+			body: []byte(`{"errorCode":100,"message":"Key not found","cause":"/foo","index":18}`),
+		},
+	}
+
+	for i, tt := range tests {
+		act := waitAction{
+			Prefix:    "/pants",
+			Key:       "/foo/bar",
+			Recursive: true,
+			WaitIndex: 19,
+		}
+
+		watcher := &httpWatcher{
+			client:   tt,
+			nextWait: act,
+		}
+
+		resp, err := watcher.Next(context.Background())
+		if err == nil {
+			t.Errorf("#%d: expected non-nil error", i)
+		}
+		if resp != nil {
+			t.Errorf("#%d: expected nil Response, got %#v", i, resp)
+		}
+		if !reflect.DeepEqual(act, watcher.nextWait) {
+			t.Errorf("#%d: nextWait changed: want=%#v got=%#v", i, act, watcher.nextWait)
+		}
+	}
+}
+
+func TestHTTPKeysAPIWatcherAction(t *testing.T) {
+	tests := []struct {
+		key  string
+		opts *WatcherOptions
+		want waitAction
+	}{
+		{
+			key:  "/foo",
+			opts: nil,
+			want: waitAction{
+				Key:       "/foo",
+				Recursive: false,
+				WaitIndex: 0,
+			},
+		},
+
+		{
+			key: "/foo",
+			opts: &WatcherOptions{
+				Recursive:  false,
+				AfterIndex: 0,
+			},
+			want: waitAction{
+				Key:       "/foo",
+				Recursive: false,
+				WaitIndex: 0,
+			},
+		},
+
+		{
+			key: "/foo",
+			opts: &WatcherOptions{
+				Recursive:  true,
+				AfterIndex: 0,
+			},
+			want: waitAction{
+				Key:       "/foo",
+				Recursive: true,
+				WaitIndex: 0,
+			},
+		},
+
+		{
+			key: "/foo",
+			opts: &WatcherOptions{
+				Recursive:  false,
+				AfterIndex: 19,
+			},
+			want: waitAction{
+				Key:       "/foo",
+				Recursive: false,
+				WaitIndex: 20,
+			},
+		},
+	}
+
+	for i, tt := range tests {
+		kAPI := &httpKeysAPI{
+			client: &staticHTTPClient{err: errors.New("fail!")},
+		}
+
+		want := &httpWatcher{
+			client:   &staticHTTPClient{err: errors.New("fail!")},
+			nextWait: tt.want,
+		}
+
+		got := kAPI.Watcher(tt.key, tt.opts)
+		if !reflect.DeepEqual(want, got) {
+			t.Errorf("#%d: incorrect watcher: want=%#v got=%#v", i, want, got)
+		}
+	}
+}
+
+func TestHTTPKeysAPISetAction(t *testing.T) {
+	tests := []struct {
+		key        string
+		value      string
+		opts       *SetOptions
+		wantAction httpAction
+	}{
+		// nil SetOptions
+		{
+			key:   "/foo",
+			value: "bar",
+			opts:  nil,
+			wantAction: &setAction{
+				Key:       "/foo",
+				Value:     "bar",
+				PrevValue: "",
+				PrevIndex: 0,
+				PrevExist: PrevIgnore,
+				TTL:       0,
+			},
+		},
+		// empty SetOptions
+		{
+			key:   "/foo",
+			value: "bar",
+			opts:  &SetOptions{},
+			wantAction: &setAction{
+				Key:       "/foo",
+				Value:     "bar",
+				PrevValue: "",
+				PrevIndex: 0,
+				PrevExist: PrevIgnore,
+				TTL:       0,
+			},
+		},
+		// populated SetOptions
+		{
+			key:   "/foo",
+			value: "bar",
+			opts: &SetOptions{
+				PrevValue: "baz",
+				PrevIndex: 13,
+				PrevExist: PrevExist,
+				TTL:       time.Minute,
+				Dir:       true,
+			},
+			wantAction: &setAction{
+				Key:       "/foo",
+				Value:     "bar",
+				PrevValue: "baz",
+				PrevIndex: 13,
+				PrevExist: PrevExist,
+				TTL:       time.Minute,
+				Dir:       true,
+			},
+		},
+	}
+
+	for i, tt := range tests {
+		client := &actionAssertingHTTPClient{t: t, num: i, act: tt.wantAction}
+		kAPI := httpKeysAPI{client: client}
+		kAPI.Set(context.Background(), tt.key, tt.value, tt.opts)
+	}
+}
+
+func TestHTTPKeysAPISetError(t *testing.T) {
+	tests := []httpClient{
+		// generic HTTP client failure
+		&staticHTTPClient{
+			err: errors.New("fail!"),
+		},
+
+		// unusable status code
+		&staticHTTPClient{
+			resp: http.Response{
+				StatusCode: http.StatusTeapot,
+			},
+		},
+
+		// etcd Error response
+		&staticHTTPClient{
+			resp: http.Response{
+				StatusCode: http.StatusInternalServerError,
+			},
+			body: []byte(`{"errorCode":300,"message":"Raft internal error","cause":"/foo","index":18}`),
+		},
+	}
+
+	for i, tt := range tests {
+		kAPI := httpKeysAPI{client: tt}
+		resp, err := kAPI.Set(context.Background(), "/foo", "bar", nil)
+		if err == nil {
+			t.Errorf("#%d: received nil error", i)
+		}
+		if resp != nil {
+			t.Errorf("#%d: received non-nil Response: %#v", i, resp)
+		}
+	}
+}
+
+func TestHTTPKeysAPISetResponse(t *testing.T) {
+	client := &staticHTTPClient{
+		resp: http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"X-Etcd-Index": []string{"21"}},
+		},
+		body: []byte(`{"action":"set","node":{"key":"/pants/foo/bar/baz","value":"snarf","modifiedIndex":21,"createdIndex":21},"prevNode":{"key":"/pants/foo/bar/baz","value":"snazz","modifiedIndex":20,"createdIndex":19}}`),
+	}
+
+	wantResponse := &Response{
+		Action:   "set",
+		Node:     &Node{Key: "/pants/foo/bar/baz", Value: "snarf", CreatedIndex: uint64(21), ModifiedIndex: uint64(21)},
+		PrevNode: &Node{Key: "/pants/foo/bar/baz", Value: "snazz", CreatedIndex: uint64(19), ModifiedIndex: uint64(20)},
+		Index:    uint64(21),
+	}
+
+	kAPI := &httpKeysAPI{client: client, prefix: "/pants"}
+	resp, err := kAPI.Set(context.Background(), "/foo/bar/baz", "snarf", nil)
+	if err != nil {
+		t.Errorf("non-nil error: %#v", err)
+	}
+	if !reflect.DeepEqual(wantResponse, resp) {
+		t.Errorf("incorrect Response: want=%#v got=%#v", wantResponse, resp)
+	}
+}
+
+func TestHTTPKeysAPIGetAction(t *testing.T) {
+	tests := []struct {
+		key        string
+		opts       *GetOptions
+		wantAction httpAction
+	}{
+		// nil GetOptions
+		{
+			key:  "/foo",
+			opts: nil,
+			wantAction: &getAction{
+				Key:       "/foo",
+				Sorted:    false,
+				Recursive: false,
+			},
+		},
+		// empty GetOptions
+		{
+			key:  "/foo",
+			opts: &GetOptions{},
+			wantAction: &getAction{
+				Key:       "/foo",
+				Sorted:    false,
+				Recursive: false,
+			},
+		},
+		// populated GetOptions
+		{
+			key: "/foo",
+			opts: &GetOptions{
+				Sort:      true,
+				Recursive: true,
+				Quorum:    true,
+			},
+			wantAction: &getAction{
+				Key:       "/foo",
+				Sorted:    true,
+				Recursive: true,
+				Quorum:    true,
+			},
+		},
+	}
+
+	for i, tt := range tests {
+		client := &actionAssertingHTTPClient{t: t, num: i, act: tt.wantAction}
+		kAPI := httpKeysAPI{client: client}
+		kAPI.Get(context.Background(), tt.key, tt.opts)
+	}
+}
+
+func TestHTTPKeysAPIGetError(t *testing.T) {
+	tests := []httpClient{
+		// generic HTTP client failure
+		&staticHTTPClient{
+			err: errors.New("fail!"),
+		},
+
+		// unusable status code
+		&staticHTTPClient{
+			resp: http.Response{
+				StatusCode: http.StatusTeapot,
+			},
+		},
+
+		// etcd Error response
+		&staticHTTPClient{
+			resp: http.Response{
+				StatusCode: http.StatusInternalServerError,
+			},
+			body: []byte(`{"errorCode":300,"message":"Raft internal error","cause":"/foo","index":18}`),
+		},
+	}
+
+	for i, tt := range tests {
+		kAPI := httpKeysAPI{client: tt}
+		resp, err := kAPI.Get(context.Background(), "/foo", nil)
+		if err == nil {
+			t.Errorf("#%d: received nil error", i)
+		}
+		if resp != nil {
+			t.Errorf("#%d: received non-nil Response: %#v", i, resp)
+		}
+	}
+}
+
+func TestHTTPKeysAPIGetResponse(t *testing.T) {
+	client := &staticHTTPClient{
+		resp: http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"X-Etcd-Index": []string{"42"}},
+		},
+		body: []byte(`{"action":"get","node":{"key":"/pants/foo/bar","modifiedIndex":25,"createdIndex":19,"nodes":[{"key":"/pants/foo/bar/baz","value":"snarf","createdIndex":21,"modifiedIndex":25}]}}`),
+	}
+
+	wantResponse := &Response{
+		Action: "get",
+		Node: &Node{
+			Key: "/pants/foo/bar",
+			Nodes: []*Node{
+				{Key: "/pants/foo/bar/baz", Value: "snarf", CreatedIndex: 21, ModifiedIndex: 25},
+			},
+			CreatedIndex:  uint64(19),
+			ModifiedIndex: uint64(25),
+		},
+		Index: uint64(42),
+	}
+
+	kAPI := &httpKeysAPI{client: client, prefix: "/pants"}
+	resp, err := kAPI.Get(context.Background(), "/foo/bar", &GetOptions{Recursive: true})
+	if err != nil {
+		t.Errorf("non-nil error: %#v", err)
+	}
+	if !reflect.DeepEqual(wantResponse, resp) {
+		t.Errorf("incorrect Response: want=%#v got=%#v", wantResponse, resp)
+	}
+}
+
+func TestHTTPKeysAPIDeleteAction(t *testing.T) {
+	tests := []struct {
+		key        string
+		value      string
+		opts       *DeleteOptions
+		wantAction httpAction
+	}{
+		// nil DeleteOptions
+		{
+			key:  "/foo",
+			opts: nil,
+			wantAction: &deleteAction{
+				Key:       "/foo",
+				PrevValue: "",
+				PrevIndex: 0,
+				Recursive: false,
+			},
+		},
+		// empty DeleteOptions
+		{
+			key:  "/foo",
+			opts: &DeleteOptions{},
+			wantAction: &deleteAction{
+				Key:       "/foo",
+				PrevValue: "",
+				PrevIndex: 0,
+				Recursive: false,
+			},
+		},
+		// populated DeleteOptions
+		{
+			key: "/foo",
+			opts: &DeleteOptions{
+				PrevValue: "baz",
+				PrevIndex: 13,
+				Recursive: true,
+			},
+			wantAction: &deleteAction{
+				Key:       "/foo",
+				PrevValue: "baz",
+				PrevIndex: 13,
+				Recursive: true,
+			},
+		},
+	}
+
+	for i, tt := range tests {
+		client := &actionAssertingHTTPClient{t: t, num: i, act: tt.wantAction}
+		kAPI := httpKeysAPI{client: client}
+		kAPI.Delete(context.Background(), tt.key, tt.opts)
+	}
+}
+
+func TestHTTPKeysAPIDeleteError(t *testing.T) {
+	tests := []httpClient{
+		// generic HTTP client failure
+		&staticHTTPClient{
+			err: errors.New("fail!"),
+		},
+
+		// unusable status code
+		&staticHTTPClient{
+			resp: http.Response{
+				StatusCode: http.StatusTeapot,
+			},
+		},
+
+		// etcd Error response
+		&staticHTTPClient{
+			resp: http.Response{
+				StatusCode: http.StatusInternalServerError,
+			},
+			body: []byte(`{"errorCode":300,"message":"Raft internal error","cause":"/foo","index":18}`),
+		},
+	}
+
+	for i, tt := range tests {
+		kAPI := httpKeysAPI{client: tt}
+		resp, err := kAPI.Delete(context.Background(), "/foo", nil)
+		if err == nil {
+			t.Errorf("#%d: received nil error", i)
+		}
+		if resp != nil {
+			t.Errorf("#%d: received non-nil Response: %#v", i, resp)
+		}
+	}
+}
+
+func TestHTTPKeysAPIDeleteResponse(t *testing.T) {
+	client := &staticHTTPClient{
+		resp: http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"X-Etcd-Index": []string{"22"}},
+		},
+		body: []byte(`{"action":"delete","node":{"key":"/pants/foo/bar/baz","value":"snarf","modifiedIndex":22,"createdIndex":19},"prevNode":{"key":"/pants/foo/bar/baz","value":"snazz","modifiedIndex":20,"createdIndex":19}}`),
+	}
+
+	wantResponse := &Response{
+		Action:   "delete",
+		Node:     &Node{Key: "/pants/foo/bar/baz", Value: "snarf", CreatedIndex: uint64(19), ModifiedIndex: uint64(22)},
+		PrevNode: &Node{Key: "/pants/foo/bar/baz", Value: "snazz", CreatedIndex: uint64(19), ModifiedIndex: uint64(20)},
+		Index:    uint64(22),
+	}
+
+	kAPI := &httpKeysAPI{client: client, prefix: "/pants"}
+	resp, err := kAPI.Delete(context.Background(), "/foo/bar/baz", nil)
+	if err != nil {
+		t.Errorf("non-nil error: %#v", err)
+	}
+	if !reflect.DeepEqual(wantResponse, resp) {
+		t.Errorf("incorrect Response: want=%#v got=%#v", wantResponse, resp)
+	}
+}
+
+func TestHTTPKeysAPICreateAction(t *testing.T) {
+	act := &setAction{
+		Key:       "/foo",
+		Value:     "bar",
+		PrevExist: PrevNoExist,
+		PrevIndex: 0,
+		PrevValue: "",
+		TTL:       0,
+	}
+
+	kAPI := httpKeysAPI{client: &actionAssertingHTTPClient{t: t, act: act}}
+	kAPI.Create(context.Background(), "/foo", "bar")
+}
+
+func TestHTTPKeysAPICreateInOrderAction(t *testing.T) {
+	act := &createInOrderAction{
+		Dir:   "/foo",
+		Value: "bar",
+		TTL:   0,
+	}
+	kAPI := httpKeysAPI{client: &actionAssertingHTTPClient{t: t, act: act}}
+	kAPI.CreateInOrder(context.Background(), "/foo", "bar", nil)
+}
+
+func TestHTTPKeysAPIUpdateAction(t *testing.T) {
+	act := &setAction{
+		Key:       "/foo",
+		Value:     "bar",
+		PrevExist: PrevExist,
+		PrevIndex: 0,
+		PrevValue: "",
+		TTL:       0,
+	}
+
+	kAPI := httpKeysAPI{client: &actionAssertingHTTPClient{t: t, act: act}}
+	kAPI.Update(context.Background(), "/foo", "bar")
+}
+
+func TestNodeTTLDuration(t *testing.T) {
+	tests := []struct {
+		node *Node
+		want time.Duration
+	}{
+		{
+			node: &Node{TTL: 0},
+			want: 0,
+		},
+		{
+			node: &Node{TTL: 97},
+			want: 97 * time.Second,
+		},
+	}
+
+	for i, tt := range tests {
+		got := tt.node.TTLDuration()
+		if tt.want != got {
+			t.Errorf("#%d: incorrect duration: want=%v got=%v", i, tt.want, got)
+		}
+	}
+}

--- a/vendor/github.com/coreos/etcd/client/members.go
+++ b/vendor/github.com/coreos/etcd/client/members.go
@@ -1,0 +1,272 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"path"
+
+	"golang.org/x/net/context"
+
+	"github.com/coreos/etcd/pkg/types"
+)
+
+var (
+	defaultV2MembersPrefix = "/v2/members"
+)
+
+type Member struct {
+	// ID is the unique identifier of this Member.
+	ID string `json:"id"`
+
+	// Name is a human-readable, non-unique identifier of this Member.
+	Name string `json:"name"`
+
+	// PeerURLs represents the HTTP(S) endpoints this Member uses to
+	// participate in etcd's consensus protocol.
+	PeerURLs []string `json:"peerURLs"`
+
+	// ClientURLs represents the HTTP(S) endpoints on which this Member
+	// serves it's client-facing APIs.
+	ClientURLs []string `json:"clientURLs"`
+}
+
+type memberCollection []Member
+
+func (c *memberCollection) UnmarshalJSON(data []byte) error {
+	d := struct {
+		Members []Member
+	}{}
+
+	if err := json.Unmarshal(data, &d); err != nil {
+		return err
+	}
+
+	if d.Members == nil {
+		*c = make([]Member, 0)
+		return nil
+	}
+
+	*c = d.Members
+	return nil
+}
+
+type memberCreateOrUpdateRequest struct {
+	PeerURLs types.URLs
+}
+
+func (m *memberCreateOrUpdateRequest) MarshalJSON() ([]byte, error) {
+	s := struct {
+		PeerURLs []string `json:"peerURLs"`
+	}{
+		PeerURLs: make([]string, len(m.PeerURLs)),
+	}
+
+	for i, u := range m.PeerURLs {
+		s.PeerURLs[i] = u.String()
+	}
+
+	return json.Marshal(&s)
+}
+
+// NewMembersAPI constructs a new MembersAPI that uses HTTP to
+// interact with etcd's membership API.
+func NewMembersAPI(c Client) MembersAPI {
+	return &httpMembersAPI{
+		client: c,
+	}
+}
+
+type MembersAPI interface {
+	// List enumerates the current cluster membership.
+	List(ctx context.Context) ([]Member, error)
+
+	// Add instructs etcd to accept a new Member into the cluster.
+	Add(ctx context.Context, peerURL string) (*Member, error)
+
+	// Remove demotes an existing Member out of the cluster.
+	Remove(ctx context.Context, mID string) error
+
+	// Update instructs etcd to update an existing Member in the cluster.
+	Update(ctx context.Context, mID string, peerURLs []string) error
+}
+
+type httpMembersAPI struct {
+	client httpClient
+}
+
+func (m *httpMembersAPI) List(ctx context.Context) ([]Member, error) {
+	req := &membersAPIActionList{}
+	resp, body, err := m.client.Do(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := assertStatusCode(resp.StatusCode, http.StatusOK); err != nil {
+		return nil, err
+	}
+
+	var mCollection memberCollection
+	if err := json.Unmarshal(body, &mCollection); err != nil {
+		return nil, err
+	}
+
+	return []Member(mCollection), nil
+}
+
+func (m *httpMembersAPI) Add(ctx context.Context, peerURL string) (*Member, error) {
+	urls, err := types.NewURLs([]string{peerURL})
+	if err != nil {
+		return nil, err
+	}
+
+	req := &membersAPIActionAdd{peerURLs: urls}
+	resp, body, err := m.client.Do(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := assertStatusCode(resp.StatusCode, http.StatusCreated, http.StatusConflict); err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusCreated {
+		var merr membersError
+		if err := json.Unmarshal(body, &merr); err != nil {
+			return nil, err
+		}
+		return nil, merr
+	}
+
+	var memb Member
+	if err := json.Unmarshal(body, &memb); err != nil {
+		return nil, err
+	}
+
+	return &memb, nil
+}
+
+func (m *httpMembersAPI) Update(ctx context.Context, memberID string, peerURLs []string) error {
+	urls, err := types.NewURLs(peerURLs)
+	if err != nil {
+		return err
+	}
+
+	req := &membersAPIActionUpdate{peerURLs: urls, memberID: memberID}
+	resp, body, err := m.client.Do(ctx, req)
+	if err != nil {
+		return err
+	}
+
+	if err := assertStatusCode(resp.StatusCode, http.StatusNoContent, http.StatusNotFound, http.StatusConflict); err != nil {
+		return err
+	}
+
+	if resp.StatusCode != http.StatusNoContent {
+		var merr membersError
+		if err := json.Unmarshal(body, &merr); err != nil {
+			return err
+		}
+		return merr
+	}
+
+	return nil
+}
+
+func (m *httpMembersAPI) Remove(ctx context.Context, memberID string) error {
+	req := &membersAPIActionRemove{memberID: memberID}
+	resp, _, err := m.client.Do(ctx, req)
+	if err != nil {
+		return err
+	}
+
+	return assertStatusCode(resp.StatusCode, http.StatusNoContent, http.StatusGone)
+}
+
+type membersAPIActionList struct{}
+
+func (l *membersAPIActionList) HTTPRequest(ep url.URL) *http.Request {
+	u := v2MembersURL(ep)
+	req, _ := http.NewRequest("GET", u.String(), nil)
+	return req
+}
+
+type membersAPIActionRemove struct {
+	memberID string
+}
+
+func (d *membersAPIActionRemove) HTTPRequest(ep url.URL) *http.Request {
+	u := v2MembersURL(ep)
+	u.Path = path.Join(u.Path, d.memberID)
+	req, _ := http.NewRequest("DELETE", u.String(), nil)
+	return req
+}
+
+type membersAPIActionAdd struct {
+	peerURLs types.URLs
+}
+
+func (a *membersAPIActionAdd) HTTPRequest(ep url.URL) *http.Request {
+	u := v2MembersURL(ep)
+	m := memberCreateOrUpdateRequest{PeerURLs: a.peerURLs}
+	b, _ := json.Marshal(&m)
+	req, _ := http.NewRequest("POST", u.String(), bytes.NewReader(b))
+	req.Header.Set("Content-Type", "application/json")
+	return req
+}
+
+type membersAPIActionUpdate struct {
+	memberID string
+	peerURLs types.URLs
+}
+
+func (a *membersAPIActionUpdate) HTTPRequest(ep url.URL) *http.Request {
+	u := v2MembersURL(ep)
+	m := memberCreateOrUpdateRequest{PeerURLs: a.peerURLs}
+	u.Path = path.Join(u.Path, a.memberID)
+	b, _ := json.Marshal(&m)
+	req, _ := http.NewRequest("PUT", u.String(), bytes.NewReader(b))
+	req.Header.Set("Content-Type", "application/json")
+	return req
+}
+
+func assertStatusCode(got int, want ...int) (err error) {
+	for _, w := range want {
+		if w == got {
+			return nil
+		}
+	}
+	return fmt.Errorf("unexpected status code %d", got)
+}
+
+// v2MembersURL add the necessary path to the provided endpoint
+// to route requests to the default v2 members API.
+func v2MembersURL(ep url.URL) *url.URL {
+	ep.Path = path.Join(ep.Path, defaultV2MembersPrefix)
+	return &ep
+}
+
+type membersError struct {
+	Message string `json:"message"`
+	Code    int    `json:"-"`
+}
+
+func (e membersError) Error() string {
+	return e.Message
+}

--- a/vendor/github.com/coreos/etcd/client/members_test.go
+++ b/vendor/github.com/coreos/etcd/client/members_test.go
@@ -1,0 +1,522 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/url"
+	"reflect"
+	"testing"
+
+	"golang.org/x/net/context"
+
+	"github.com/coreos/etcd/pkg/types"
+)
+
+func TestMembersAPIActionList(t *testing.T) {
+	ep := url.URL{Scheme: "http", Host: "example.com"}
+	act := &membersAPIActionList{}
+
+	wantURL := &url.URL{
+		Scheme: "http",
+		Host:   "example.com",
+		Path:   "/v2/members",
+	}
+
+	got := *act.HTTPRequest(ep)
+	err := assertRequest(got, "GET", wantURL, http.Header{}, nil)
+	if err != nil {
+		t.Error(err.Error())
+	}
+}
+
+func TestMembersAPIActionAdd(t *testing.T) {
+	ep := url.URL{Scheme: "http", Host: "example.com"}
+	act := &membersAPIActionAdd{
+		peerURLs: types.URLs([]url.URL{
+			{Scheme: "https", Host: "127.0.0.1:8081"},
+			{Scheme: "http", Host: "127.0.0.1:8080"},
+		}),
+	}
+
+	wantURL := &url.URL{
+		Scheme: "http",
+		Host:   "example.com",
+		Path:   "/v2/members",
+	}
+	wantHeader := http.Header{
+		"Content-Type": []string{"application/json"},
+	}
+	wantBody := []byte(`{"peerURLs":["https://127.0.0.1:8081","http://127.0.0.1:8080"]}`)
+
+	got := *act.HTTPRequest(ep)
+	err := assertRequest(got, "POST", wantURL, wantHeader, wantBody)
+	if err != nil {
+		t.Error(err.Error())
+	}
+}
+
+func TestMembersAPIActionUpdate(t *testing.T) {
+	ep := url.URL{Scheme: "http", Host: "example.com"}
+	act := &membersAPIActionUpdate{
+		memberID: "0xabcd",
+		peerURLs: types.URLs([]url.URL{
+			{Scheme: "https", Host: "127.0.0.1:8081"},
+			{Scheme: "http", Host: "127.0.0.1:8080"},
+		}),
+	}
+
+	wantURL := &url.URL{
+		Scheme: "http",
+		Host:   "example.com",
+		Path:   "/v2/members/0xabcd",
+	}
+	wantHeader := http.Header{
+		"Content-Type": []string{"application/json"},
+	}
+	wantBody := []byte(`{"peerURLs":["https://127.0.0.1:8081","http://127.0.0.1:8080"]}`)
+
+	got := *act.HTTPRequest(ep)
+	err := assertRequest(got, "PUT", wantURL, wantHeader, wantBody)
+	if err != nil {
+		t.Error(err.Error())
+	}
+}
+
+func TestMembersAPIActionRemove(t *testing.T) {
+	ep := url.URL{Scheme: "http", Host: "example.com"}
+	act := &membersAPIActionRemove{memberID: "XXX"}
+
+	wantURL := &url.URL{
+		Scheme: "http",
+		Host:   "example.com",
+		Path:   "/v2/members/XXX",
+	}
+
+	got := *act.HTTPRequest(ep)
+	err := assertRequest(got, "DELETE", wantURL, http.Header{}, nil)
+	if err != nil {
+		t.Error(err.Error())
+	}
+}
+
+func TestAssertStatusCode(t *testing.T) {
+	if err := assertStatusCode(404, 400); err == nil {
+		t.Errorf("assertStatusCode failed to detect conflict in 400 vs 404")
+	}
+
+	if err := assertStatusCode(404, 400, 404); err != nil {
+		t.Errorf("assertStatusCode found conflict in (404,400) vs 400: %v", err)
+	}
+}
+
+func TestV2MembersURL(t *testing.T) {
+	got := v2MembersURL(url.URL{
+		Scheme: "http",
+		Host:   "foo.example.com:4002",
+		Path:   "/pants",
+	})
+	want := &url.URL{
+		Scheme: "http",
+		Host:   "foo.example.com:4002",
+		Path:   "/pants/v2/members",
+	}
+
+	if !reflect.DeepEqual(want, got) {
+		t.Fatalf("v2MembersURL got %#v, want %#v", got, want)
+	}
+}
+
+func TestMemberUnmarshal(t *testing.T) {
+	tests := []struct {
+		body       []byte
+		wantMember Member
+		wantError  bool
+	}{
+		// no URLs, just check ID & Name
+		{
+			body:       []byte(`{"id": "c", "name": "dungarees"}`),
+			wantMember: Member{ID: "c", Name: "dungarees", PeerURLs: nil, ClientURLs: nil},
+		},
+
+		// both client and peer URLs
+		{
+			body: []byte(`{"peerURLs": ["http://127.0.0.1:2379"], "clientURLs": ["http://127.0.0.1:2379"]}`),
+			wantMember: Member{
+				PeerURLs: []string{
+					"http://127.0.0.1:2379",
+				},
+				ClientURLs: []string{
+					"http://127.0.0.1:2379",
+				},
+			},
+		},
+
+		// multiple peer URLs
+		{
+			body: []byte(`{"peerURLs": ["http://127.0.0.1:2379", "https://example.com"]}`),
+			wantMember: Member{
+				PeerURLs: []string{
+					"http://127.0.0.1:2379",
+					"https://example.com",
+				},
+				ClientURLs: nil,
+			},
+		},
+
+		// multiple client URLs
+		{
+			body: []byte(`{"clientURLs": ["http://127.0.0.1:2379", "https://example.com"]}`),
+			wantMember: Member{
+				PeerURLs: nil,
+				ClientURLs: []string{
+					"http://127.0.0.1:2379",
+					"https://example.com",
+				},
+			},
+		},
+
+		// invalid JSON
+		{
+			body:      []byte(`{"peerU`),
+			wantError: true,
+		},
+	}
+
+	for i, tt := range tests {
+		got := Member{}
+		err := json.Unmarshal(tt.body, &got)
+		if tt.wantError != (err != nil) {
+			t.Errorf("#%d: want error %t, got %v", i, tt.wantError, err)
+			continue
+		}
+
+		if !reflect.DeepEqual(tt.wantMember, got) {
+			t.Errorf("#%d: incorrect output: want=%#v, got=%#v", i, tt.wantMember, got)
+		}
+	}
+}
+
+func TestMemberCollectionUnmarshalFail(t *testing.T) {
+	mc := &memberCollection{}
+	if err := mc.UnmarshalJSON([]byte(`{`)); err == nil {
+		t.Errorf("got nil error")
+	}
+}
+
+func TestMemberCollectionUnmarshal(t *testing.T) {
+	tests := []struct {
+		body []byte
+		want memberCollection
+	}{
+		{
+			body: []byte(`{}`),
+			want: memberCollection([]Member{}),
+		},
+		{
+			body: []byte(`{"members":[]}`),
+			want: memberCollection([]Member{}),
+		},
+		{
+			body: []byte(`{"members":[{"id":"2745e2525fce8fe","peerURLs":["http://127.0.0.1:7003"],"name":"node3","clientURLs":["http://127.0.0.1:4003"]},{"id":"42134f434382925","peerURLs":["http://127.0.0.1:2380","http://127.0.0.1:7001"],"name":"node1","clientURLs":["http://127.0.0.1:2379","http://127.0.0.1:4001"]},{"id":"94088180e21eb87b","peerURLs":["http://127.0.0.1:7002"],"name":"node2","clientURLs":["http://127.0.0.1:4002"]}]}`),
+			want: memberCollection(
+				[]Member{
+					{
+						ID:   "2745e2525fce8fe",
+						Name: "node3",
+						PeerURLs: []string{
+							"http://127.0.0.1:7003",
+						},
+						ClientURLs: []string{
+							"http://127.0.0.1:4003",
+						},
+					},
+					{
+						ID:   "42134f434382925",
+						Name: "node1",
+						PeerURLs: []string{
+							"http://127.0.0.1:2380",
+							"http://127.0.0.1:7001",
+						},
+						ClientURLs: []string{
+							"http://127.0.0.1:2379",
+							"http://127.0.0.1:4001",
+						},
+					},
+					{
+						ID:   "94088180e21eb87b",
+						Name: "node2",
+						PeerURLs: []string{
+							"http://127.0.0.1:7002",
+						},
+						ClientURLs: []string{
+							"http://127.0.0.1:4002",
+						},
+					},
+				},
+			),
+		},
+	}
+
+	for i, tt := range tests {
+		var got memberCollection
+		err := json.Unmarshal(tt.body, &got)
+		if err != nil {
+			t.Errorf("#%d: unexpected error: %v", i, err)
+			continue
+		}
+
+		if !reflect.DeepEqual(tt.want, got) {
+			t.Errorf("#%d: incorrect output: want=%#v, got=%#v", i, tt.want, got)
+		}
+	}
+}
+
+func TestMemberCreateRequestMarshal(t *testing.T) {
+	req := memberCreateOrUpdateRequest{
+		PeerURLs: types.URLs([]url.URL{
+			{Scheme: "http", Host: "127.0.0.1:8081"},
+			{Scheme: "https", Host: "127.0.0.1:8080"},
+		}),
+	}
+	want := []byte(`{"peerURLs":["http://127.0.0.1:8081","https://127.0.0.1:8080"]}`)
+
+	got, err := json.Marshal(&req)
+	if err != nil {
+		t.Fatalf("Marshal returned unexpected err=%v", err)
+	}
+
+	if !reflect.DeepEqual(want, got) {
+		t.Fatalf("Failed to marshal memberCreateRequest: want=%s, got=%s", want, got)
+	}
+}
+
+func TestHTTPMembersAPIAddSuccess(t *testing.T) {
+	wantAction := &membersAPIActionAdd{
+		peerURLs: types.URLs([]url.URL{
+			{Scheme: "http", Host: "127.0.0.1:7002"},
+		}),
+	}
+
+	mAPI := &httpMembersAPI{
+		client: &actionAssertingHTTPClient{
+			t:   t,
+			act: wantAction,
+			resp: http.Response{
+				StatusCode: http.StatusCreated,
+			},
+			body: []byte(`{"id":"94088180e21eb87b","peerURLs":["http://127.0.0.1:7002"]}`),
+		},
+	}
+
+	wantResponseMember := &Member{
+		ID:       "94088180e21eb87b",
+		PeerURLs: []string{"http://127.0.0.1:7002"},
+	}
+
+	m, err := mAPI.Add(context.Background(), "http://127.0.0.1:7002")
+	if err != nil {
+		t.Errorf("got non-nil err: %#v", err)
+	}
+	if !reflect.DeepEqual(wantResponseMember, m) {
+		t.Errorf("incorrect Member: want=%#v got=%#v", wantResponseMember, m)
+	}
+}
+
+func TestHTTPMembersAPIAddError(t *testing.T) {
+	okPeer := "http://example.com:2379"
+	tests := []struct {
+		peerURL string
+		client  httpClient
+
+		// if wantErr == nil, assert that the returned error is non-nil
+		// if wantErr != nil, assert that the returned error matches
+		wantErr error
+	}{
+		// malformed peer URL
+		{
+			peerURL: ":",
+		},
+
+		// generic httpClient failure
+		{
+			peerURL: okPeer,
+			client:  &staticHTTPClient{err: errors.New("fail!")},
+		},
+
+		// unrecognized HTTP status code
+		{
+			peerURL: okPeer,
+			client: &staticHTTPClient{
+				resp: http.Response{StatusCode: http.StatusTeapot},
+			},
+		},
+
+		// unmarshal body into membersError on StatusConflict
+		{
+			peerURL: okPeer,
+			client: &staticHTTPClient{
+				resp: http.Response{
+					StatusCode: http.StatusConflict,
+				},
+				body: []byte(`{"message":"fail!"}`),
+			},
+			wantErr: membersError{Message: "fail!"},
+		},
+
+		// fail to unmarshal body on StatusConflict
+		{
+			peerURL: okPeer,
+			client: &staticHTTPClient{
+				resp: http.Response{
+					StatusCode: http.StatusConflict,
+				},
+				body: []byte(`{"`),
+			},
+		},
+
+		// fail to unmarshal body on StatusCreated
+		{
+			peerURL: okPeer,
+			client: &staticHTTPClient{
+				resp: http.Response{
+					StatusCode: http.StatusCreated,
+				},
+				body: []byte(`{"id":"XX`),
+			},
+		},
+	}
+
+	for i, tt := range tests {
+		mAPI := &httpMembersAPI{client: tt.client}
+		m, err := mAPI.Add(context.Background(), tt.peerURL)
+		if err == nil {
+			t.Errorf("#%d: got nil err", i)
+		}
+		if tt.wantErr != nil && !reflect.DeepEqual(tt.wantErr, err) {
+			t.Errorf("#%d: incorrect error: want=%#v got=%#v", i, tt.wantErr, err)
+		}
+		if m != nil {
+			t.Errorf("#%d: got non-nil Member", i)
+		}
+	}
+}
+
+func TestHTTPMembersAPIRemoveSuccess(t *testing.T) {
+	wantAction := &membersAPIActionRemove{
+		memberID: "94088180e21eb87b",
+	}
+
+	mAPI := &httpMembersAPI{
+		client: &actionAssertingHTTPClient{
+			t:   t,
+			act: wantAction,
+			resp: http.Response{
+				StatusCode: http.StatusNoContent,
+			},
+		},
+	}
+
+	if err := mAPI.Remove(context.Background(), "94088180e21eb87b"); err != nil {
+		t.Errorf("got non-nil err: %#v", err)
+	}
+}
+
+func TestHTTPMembersAPIRemoveFail(t *testing.T) {
+	tests := []httpClient{
+		// generic error
+		&staticHTTPClient{
+			err: errors.New("fail!"),
+		},
+
+		// unexpected HTTP status code
+		&staticHTTPClient{
+			resp: http.Response{
+				StatusCode: http.StatusInternalServerError,
+			},
+		},
+	}
+
+	for i, tt := range tests {
+		mAPI := &httpMembersAPI{client: tt}
+		if err := mAPI.Remove(context.Background(), "94088180e21eb87b"); err == nil {
+			t.Errorf("#%d: got nil err", i)
+		}
+	}
+}
+
+func TestHTTPMembersAPIListSuccess(t *testing.T) {
+	wantAction := &membersAPIActionList{}
+	mAPI := &httpMembersAPI{
+		client: &actionAssertingHTTPClient{
+			t:   t,
+			act: wantAction,
+			resp: http.Response{
+				StatusCode: http.StatusOK,
+			},
+			body: []byte(`{"members":[{"id":"94088180e21eb87b","name":"node2","peerURLs":["http://127.0.0.1:7002"],"clientURLs":["http://127.0.0.1:4002"]}]}`),
+		},
+	}
+
+	wantResponseMembers := []Member{
+		{
+			ID:         "94088180e21eb87b",
+			Name:       "node2",
+			PeerURLs:   []string{"http://127.0.0.1:7002"},
+			ClientURLs: []string{"http://127.0.0.1:4002"},
+		},
+	}
+
+	m, err := mAPI.List(context.Background())
+	if err != nil {
+		t.Errorf("got non-nil err: %#v", err)
+	}
+	if !reflect.DeepEqual(wantResponseMembers, m) {
+		t.Errorf("incorrect Members: want=%#v got=%#v", wantResponseMembers, m)
+	}
+}
+
+func TestHTTPMembersAPIListError(t *testing.T) {
+	tests := []httpClient{
+		// generic httpClient failure
+		&staticHTTPClient{err: errors.New("fail!")},
+
+		// unrecognized HTTP status code
+		&staticHTTPClient{
+			resp: http.Response{StatusCode: http.StatusTeapot},
+		},
+
+		// fail to unmarshal body on StatusOK
+		&staticHTTPClient{
+			resp: http.Response{
+				StatusCode: http.StatusOK,
+			},
+			body: []byte(`[{"id":"XX`),
+		},
+	}
+
+	for i, tt := range tests {
+		mAPI := &httpMembersAPI{client: tt}
+		ms, err := mAPI.List(context.Background())
+		if err == nil {
+			t.Errorf("#%d: got nil err", i)
+		}
+		if ms != nil {
+			t.Errorf("#%d: got non-nil Member slice", i)
+		}
+	}
+}

--- a/vendor/github.com/coreos/etcd/client/srv.go
+++ b/vendor/github.com/coreos/etcd/client/srv.go
@@ -1,0 +1,65 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+)
+
+var (
+	// indirection for testing
+	lookupSRV = net.LookupSRV
+)
+
+type srvDiscover struct{}
+
+// NewSRVDiscover constructs a new Dicoverer that uses the stdlib to lookup SRV records.
+func NewSRVDiscover() Discoverer {
+	return &srvDiscover{}
+}
+
+// Discover looks up the etcd servers for the domain.
+func (d *srvDiscover) Discover(domain string) ([]string, error) {
+	var urls []*url.URL
+
+	updateURLs := func(service, scheme string) error {
+		_, addrs, err := lookupSRV(service, "tcp", domain)
+		if err != nil {
+			return err
+		}
+		for _, srv := range addrs {
+			urls = append(urls, &url.URL{
+				Scheme: scheme,
+				Host:   net.JoinHostPort(srv.Target, fmt.Sprintf("%d", srv.Port)),
+			})
+		}
+		return nil
+	}
+
+	errHTTPS := updateURLs("etcd-server-ssl", "https")
+	errHTTP := updateURLs("etcd-server", "http")
+
+	if errHTTPS != nil && errHTTP != nil {
+		return nil, fmt.Errorf("dns lookup errors: %s and %s", errHTTPS, errHTTP)
+	}
+
+	endpoints := make([]string, len(urls))
+	for i := range urls {
+		endpoints[i] = urls[i].String()
+	}
+	return endpoints, nil
+}

--- a/vendor/github.com/coreos/etcd/client/srv_test.go
+++ b/vendor/github.com/coreos/etcd/client/srv_test.go
@@ -1,0 +1,102 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"errors"
+	"net"
+	"reflect"
+	"testing"
+)
+
+func TestSRVDiscover(t *testing.T) {
+	defer func() { lookupSRV = net.LookupSRV }()
+
+	tests := []struct {
+		withSSL    []*net.SRV
+		withoutSSL []*net.SRV
+		expected   []string
+	}{
+		{
+			[]*net.SRV{},
+			[]*net.SRV{},
+			[]string{},
+		},
+		{
+			[]*net.SRV{
+				{Target: "10.0.0.1", Port: 2480},
+				{Target: "10.0.0.2", Port: 2480},
+				{Target: "10.0.0.3", Port: 2480},
+			},
+			[]*net.SRV{},
+			[]string{"https://10.0.0.1:2480", "https://10.0.0.2:2480", "https://10.0.0.3:2480"},
+		},
+		{
+			[]*net.SRV{
+				{Target: "10.0.0.1", Port: 2480},
+				{Target: "10.0.0.2", Port: 2480},
+				{Target: "10.0.0.3", Port: 2480},
+			},
+			[]*net.SRV{
+				{Target: "10.0.0.1", Port: 7001},
+			},
+			[]string{"https://10.0.0.1:2480", "https://10.0.0.2:2480", "https://10.0.0.3:2480", "http://10.0.0.1:7001"},
+		},
+		{
+			[]*net.SRV{
+				{Target: "10.0.0.1", Port: 2480},
+				{Target: "10.0.0.2", Port: 2480},
+				{Target: "10.0.0.3", Port: 2480},
+			},
+			[]*net.SRV{
+				{Target: "10.0.0.1", Port: 7001},
+			},
+			[]string{"https://10.0.0.1:2480", "https://10.0.0.2:2480", "https://10.0.0.3:2480", "http://10.0.0.1:7001"},
+		},
+		{
+			[]*net.SRV{
+				{Target: "a.example.com", Port: 2480},
+				{Target: "b.example.com", Port: 2480},
+				{Target: "c.example.com", Port: 2480},
+			},
+			[]*net.SRV{},
+			[]string{"https://a.example.com:2480", "https://b.example.com:2480", "https://c.example.com:2480"},
+		},
+	}
+
+	for i, tt := range tests {
+		lookupSRV = func(service string, proto string, domain string) (string, []*net.SRV, error) {
+			if service == "etcd-server-ssl" {
+				return "", tt.withSSL, nil
+			}
+			if service == "etcd-server" {
+				return "", tt.withoutSSL, nil
+			}
+			return "", nil, errors.New("Unkown service in mock")
+		}
+
+		d := NewSRVDiscover()
+
+		endpoints, err := d.Discover("example.com")
+		if err != nil {
+			t.Fatalf("%d: err: %#v", i, err)
+		}
+
+		if !reflect.DeepEqual(endpoints, tt.expected) {
+			t.Errorf("#%d: endpoints = %v, want %v", i, endpoints, tt.expected)
+		}
+
+	}
+}

--- a/vendor/github.com/coreos/etcd/pkg/pathutil/path.go
+++ b/vendor/github.com/coreos/etcd/pkg/pathutil/path.go
@@ -1,0 +1,29 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package pathutil
+
+import "path"
+
+// CanonicalURLPath returns the canonical url path for p, which follows the rules:
+// 1. the path always starts with "/"
+// 2. replace multiple slashes with a single slash
+// 3. replace each '.' '..' path name element with equivalent one
+// 4. keep the trailing slash
+// The function is borrowed from stdlib http.cleanPath in server.go.
+func CanonicalURLPath(p string) string {
+	if p == "" {
+		return "/"
+	}
+	if p[0] != '/' {
+		p = "/" + p
+	}
+	np := path.Clean(p)
+	// path.Clean removes trailing slash except for root,
+	// put the trailing slash back if necessary.
+	if p[len(p)-1] == '/' && np != "/" {
+		np += "/"
+	}
+	return np
+}

--- a/vendor/github.com/coreos/etcd/pkg/pathutil/path_test.go
+++ b/vendor/github.com/coreos/etcd/pkg/pathutil/path_test.go
@@ -1,0 +1,38 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pathutil
+
+import "testing"
+
+func TestCanonicalURLPath(t *testing.T) {
+	tests := []struct {
+		p  string
+		wp string
+	}{
+		{"/a", "/a"},
+		{"", "/"},
+		{"a", "/a"},
+		{"//a", "/a"},
+		{"/a/.", "/a"},
+		{"/a/..", "/"},
+		{"/a/", "/a/"},
+		{"/a//", "/a/"},
+	}
+	for i, tt := range tests {
+		if g := CanonicalURLPath(tt.p); g != tt.wp {
+			t.Errorf("#%d: canonical path = %s, want %s", i, g, tt.wp)
+		}
+	}
+}

--- a/vendor/github.com/coreos/etcd/pkg/types/id.go
+++ b/vendor/github.com/coreos/etcd/pkg/types/id.go
@@ -1,0 +1,41 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"strconv"
+)
+
+// ID represents a generic identifier which is canonically
+// stored as a uint64 but is typically represented as a
+// base-16 string for input/output
+type ID uint64
+
+func (i ID) String() string {
+	return strconv.FormatUint(uint64(i), 16)
+}
+
+// IDFromString attempts to create an ID from a base-16 string.
+func IDFromString(s string) (ID, error) {
+	i, err := strconv.ParseUint(s, 16, 64)
+	return ID(i), err
+}
+
+// IDSlice implements the sort interface
+type IDSlice []ID
+
+func (p IDSlice) Len() int           { return len(p) }
+func (p IDSlice) Less(i, j int) bool { return uint64(p[i]) < uint64(p[j]) }
+func (p IDSlice) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }

--- a/vendor/github.com/coreos/etcd/pkg/types/id_test.go
+++ b/vendor/github.com/coreos/etcd/pkg/types/id_test.go
@@ -1,0 +1,95 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func TestIDString(t *testing.T) {
+	tests := []struct {
+		input ID
+		want  string
+	}{
+		{
+			input: 12,
+			want:  "c",
+		},
+		{
+			input: 4918257920282737594,
+			want:  "444129853c343bba",
+		},
+	}
+
+	for i, tt := range tests {
+		got := tt.input.String()
+		if tt.want != got {
+			t.Errorf("#%d: ID.String failure: want=%v, got=%v", i, tt.want, got)
+		}
+	}
+}
+
+func TestIDFromString(t *testing.T) {
+	tests := []struct {
+		input string
+		want  ID
+	}{
+		{
+			input: "17",
+			want:  23,
+		},
+		{
+			input: "612840dae127353",
+			want:  437557308098245459,
+		},
+	}
+
+	for i, tt := range tests {
+		got, err := IDFromString(tt.input)
+		if err != nil {
+			t.Errorf("#%d: IDFromString failure: err=%v", i, err)
+			continue
+		}
+		if tt.want != got {
+			t.Errorf("#%d: IDFromString failure: want=%v, got=%v", i, tt.want, got)
+		}
+	}
+}
+
+func TestIDFromStringFail(t *testing.T) {
+	tests := []string{
+		"",
+		"XXX",
+		"612840dae127353612840dae127353",
+	}
+
+	for i, tt := range tests {
+		_, err := IDFromString(tt)
+		if err == nil {
+			t.Fatalf("#%d: IDFromString expected error, but err=nil", i)
+		}
+	}
+}
+
+func TestIDSlice(t *testing.T) {
+	g := []ID{10, 500, 5, 1, 100, 25}
+	w := []ID{1, 5, 10, 25, 100, 500}
+	sort.Sort(IDSlice(g))
+	if !reflect.DeepEqual(g, w) {
+		t.Errorf("slice after sort = %#v, want %#v", g, w)
+	}
+}

--- a/vendor/github.com/coreos/etcd/pkg/types/set.go
+++ b/vendor/github.com/coreos/etcd/pkg/types/set.go
@@ -1,0 +1,178 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"reflect"
+	"sort"
+	"sync"
+)
+
+type Set interface {
+	Add(string)
+	Remove(string)
+	Contains(string) bool
+	Equals(Set) bool
+	Length() int
+	Values() []string
+	Copy() Set
+	Sub(Set) Set
+}
+
+func NewUnsafeSet(values ...string) *unsafeSet {
+	set := &unsafeSet{make(map[string]struct{})}
+	for _, v := range values {
+		set.Add(v)
+	}
+	return set
+}
+
+func NewThreadsafeSet(values ...string) *tsafeSet {
+	us := NewUnsafeSet(values...)
+	return &tsafeSet{us, sync.RWMutex{}}
+}
+
+type unsafeSet struct {
+	d map[string]struct{}
+}
+
+// Add adds a new value to the set (no-op if the value is already present)
+func (us *unsafeSet) Add(value string) {
+	us.d[value] = struct{}{}
+}
+
+// Remove removes the given value from the set
+func (us *unsafeSet) Remove(value string) {
+	delete(us.d, value)
+}
+
+// Contains returns whether the set contains the given value
+func (us *unsafeSet) Contains(value string) (exists bool) {
+	_, exists = us.d[value]
+	return
+}
+
+// ContainsAll returns whether the set contains all given values
+func (us *unsafeSet) ContainsAll(values []string) bool {
+	for _, s := range values {
+		if !us.Contains(s) {
+			return false
+		}
+	}
+	return true
+}
+
+// Equals returns whether the contents of two sets are identical
+func (us *unsafeSet) Equals(other Set) bool {
+	v1 := sort.StringSlice(us.Values())
+	v2 := sort.StringSlice(other.Values())
+	v1.Sort()
+	v2.Sort()
+	return reflect.DeepEqual(v1, v2)
+}
+
+// Length returns the number of elements in the set
+func (us *unsafeSet) Length() int {
+	return len(us.d)
+}
+
+// Values returns the values of the Set in an unspecified order.
+func (us *unsafeSet) Values() (values []string) {
+	values = make([]string, 0)
+	for val := range us.d {
+		values = append(values, val)
+	}
+	return
+}
+
+// Copy creates a new Set containing the values of the first
+func (us *unsafeSet) Copy() Set {
+	cp := NewUnsafeSet()
+	for val := range us.d {
+		cp.Add(val)
+	}
+
+	return cp
+}
+
+// Sub removes all elements in other from the set
+func (us *unsafeSet) Sub(other Set) Set {
+	oValues := other.Values()
+	result := us.Copy().(*unsafeSet)
+
+	for _, val := range oValues {
+		if _, ok := result.d[val]; !ok {
+			continue
+		}
+		delete(result.d, val)
+	}
+
+	return result
+}
+
+type tsafeSet struct {
+	us *unsafeSet
+	m  sync.RWMutex
+}
+
+func (ts *tsafeSet) Add(value string) {
+	ts.m.Lock()
+	defer ts.m.Unlock()
+	ts.us.Add(value)
+}
+
+func (ts *tsafeSet) Remove(value string) {
+	ts.m.Lock()
+	defer ts.m.Unlock()
+	ts.us.Remove(value)
+}
+
+func (ts *tsafeSet) Contains(value string) (exists bool) {
+	ts.m.RLock()
+	defer ts.m.RUnlock()
+	return ts.us.Contains(value)
+}
+
+func (ts *tsafeSet) Equals(other Set) bool {
+	ts.m.RLock()
+	defer ts.m.RUnlock()
+	return ts.us.Equals(other)
+}
+
+func (ts *tsafeSet) Length() int {
+	ts.m.RLock()
+	defer ts.m.RUnlock()
+	return ts.us.Length()
+}
+
+func (ts *tsafeSet) Values() (values []string) {
+	ts.m.RLock()
+	defer ts.m.RUnlock()
+	return ts.us.Values()
+}
+
+func (ts *tsafeSet) Copy() Set {
+	ts.m.RLock()
+	defer ts.m.RUnlock()
+	usResult := ts.us.Copy().(*unsafeSet)
+	return &tsafeSet{usResult, sync.RWMutex{}}
+}
+
+func (ts *tsafeSet) Sub(other Set) Set {
+	ts.m.RLock()
+	defer ts.m.RUnlock()
+	usResult := ts.us.Sub(other).(*unsafeSet)
+	return &tsafeSet{usResult, sync.RWMutex{}}
+}

--- a/vendor/github.com/coreos/etcd/pkg/types/set_test.go
+++ b/vendor/github.com/coreos/etcd/pkg/types/set_test.go
@@ -1,0 +1,186 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func TestUnsafeSet(t *testing.T) {
+	driveSetTests(t, NewUnsafeSet())
+}
+
+func TestThreadsafeSet(t *testing.T) {
+	driveSetTests(t, NewThreadsafeSet())
+}
+
+// Check that two slices contents are equal; order is irrelevant
+func equal(a, b []string) bool {
+	as := sort.StringSlice(a)
+	bs := sort.StringSlice(b)
+	as.Sort()
+	bs.Sort()
+	return reflect.DeepEqual(as, bs)
+}
+
+func driveSetTests(t *testing.T, s Set) {
+	// Verify operations on an empty set
+	eValues := []string{}
+	values := s.Values()
+	if !reflect.DeepEqual(values, eValues) {
+		t.Fatalf("Expect values=%v got %v", eValues, values)
+	}
+	if l := s.Length(); l != 0 {
+		t.Fatalf("Expected length=0, got %d", l)
+	}
+	for _, v := range []string{"foo", "bar", "baz"} {
+		if s.Contains(v) {
+			t.Fatalf("Expect s.Contains(%q) to be fale, got true", v)
+		}
+	}
+
+	// Add three items, ensure they show up
+	s.Add("foo")
+	s.Add("bar")
+	s.Add("baz")
+
+	eValues = []string{"foo", "bar", "baz"}
+	values = s.Values()
+	if !equal(values, eValues) {
+		t.Fatalf("Expect values=%v got %v", eValues, values)
+	}
+
+	for _, v := range eValues {
+		if !s.Contains(v) {
+			t.Fatalf("Expect s.Contains(%q) to be true, got false", v)
+		}
+	}
+
+	if l := s.Length(); l != 3 {
+		t.Fatalf("Expected length=3, got %d", l)
+	}
+
+	// Add the same item a second time, ensuring it is not duplicated
+	s.Add("foo")
+
+	values = s.Values()
+	if !equal(values, eValues) {
+		t.Fatalf("Expect values=%v got %v", eValues, values)
+	}
+	if l := s.Length(); l != 3 {
+		t.Fatalf("Expected length=3, got %d", l)
+	}
+
+	// Remove all items, ensure they are gone
+	s.Remove("foo")
+	s.Remove("bar")
+	s.Remove("baz")
+
+	eValues = []string{}
+	values = s.Values()
+	if !equal(values, eValues) {
+		t.Fatalf("Expect values=%v got %v", eValues, values)
+	}
+
+	if l := s.Length(); l != 0 {
+		t.Fatalf("Expected length=0, got %d", l)
+	}
+
+	// Create new copies of the set, and ensure they are unlinked to the
+	// original Set by making modifications
+	s.Add("foo")
+	s.Add("bar")
+	cp1 := s.Copy()
+	cp2 := s.Copy()
+	s.Remove("foo")
+	cp3 := s.Copy()
+	cp1.Add("baz")
+
+	for i, tt := range []struct {
+		want []string
+		got  []string
+	}{
+		{[]string{"bar"}, s.Values()},
+		{[]string{"foo", "bar", "baz"}, cp1.Values()},
+		{[]string{"foo", "bar"}, cp2.Values()},
+		{[]string{"bar"}, cp3.Values()},
+	} {
+		if !equal(tt.want, tt.got) {
+			t.Fatalf("case %d: expect values=%v got %v", i, tt.want, tt.got)
+		}
+	}
+
+	for i, tt := range []struct {
+		want bool
+		got  bool
+	}{
+		{true, s.Equals(cp3)},
+		{true, cp3.Equals(s)},
+		{false, s.Equals(cp2)},
+		{false, s.Equals(cp1)},
+		{false, cp1.Equals(s)},
+		{false, cp2.Equals(s)},
+		{false, cp2.Equals(cp1)},
+	} {
+		if tt.got != tt.want {
+			t.Fatalf("case %d: want %t, got %t", i, tt.want, tt.got)
+
+		}
+	}
+
+	// Subtract values from a Set, ensuring a new Set is created and
+	// the original Sets are unmodified
+	sub1 := cp1.Sub(s)
+	sub2 := cp2.Sub(cp1)
+
+	for i, tt := range []struct {
+		want []string
+		got  []string
+	}{
+		{[]string{"foo", "bar", "baz"}, cp1.Values()},
+		{[]string{"foo", "bar"}, cp2.Values()},
+		{[]string{"bar"}, s.Values()},
+		{[]string{"foo", "baz"}, sub1.Values()},
+		{[]string{}, sub2.Values()},
+	} {
+		if !equal(tt.want, tt.got) {
+			t.Fatalf("case %d: expect values=%v got %v", i, tt.want, tt.got)
+		}
+	}
+}
+
+func TestUnsafeSetContainsAll(t *testing.T) {
+	vals := []string{"foo", "bar", "baz"}
+	s := NewUnsafeSet(vals...)
+
+	tests := []struct {
+		strs     []string
+		wcontain bool
+	}{
+		{[]string{}, true},
+		{vals[:1], true},
+		{vals[:2], true},
+		{vals, true},
+		{[]string{"cuz"}, false},
+		{[]string{vals[0], "cuz"}, false},
+	}
+	for i, tt := range tests {
+		if g := s.ContainsAll(tt.strs); g != tt.wcontain {
+			t.Errorf("#%d: ok = %v, want %v", i, g, tt.wcontain)
+		}
+	}
+}

--- a/vendor/github.com/coreos/etcd/pkg/types/slice.go
+++ b/vendor/github.com/coreos/etcd/pkg/types/slice.go
@@ -1,0 +1,22 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+// Uint64Slice implements sort interface
+type Uint64Slice []uint64
+
+func (p Uint64Slice) Len() int           { return len(p) }
+func (p Uint64Slice) Less(i, j int) bool { return p[i] < p[j] }
+func (p Uint64Slice) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }

--- a/vendor/github.com/coreos/etcd/pkg/types/slice_test.go
+++ b/vendor/github.com/coreos/etcd/pkg/types/slice_test.go
@@ -1,0 +1,30 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func TestUint64Slice(t *testing.T) {
+	g := Uint64Slice{10, 500, 5, 1, 100, 25}
+	w := Uint64Slice{1, 5, 10, 25, 100, 500}
+	sort.Sort(g)
+	if !reflect.DeepEqual(g, w) {
+		t.Errorf("slice after sort = %#v, want %#v", g, w)
+	}
+}

--- a/vendor/github.com/coreos/etcd/pkg/types/urls.go
+++ b/vendor/github.com/coreos/etcd/pkg/types/urls.go
@@ -1,0 +1,74 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/url"
+	"sort"
+	"strings"
+)
+
+type URLs []url.URL
+
+func NewURLs(strs []string) (URLs, error) {
+	all := make([]url.URL, len(strs))
+	if len(all) == 0 {
+		return nil, errors.New("no valid URLs given")
+	}
+	for i, in := range strs {
+		in = strings.TrimSpace(in)
+		u, err := url.Parse(in)
+		if err != nil {
+			return nil, err
+		}
+		if u.Scheme != "http" && u.Scheme != "https" {
+			return nil, fmt.Errorf("URL scheme must be http or https: %s", in)
+		}
+		if _, _, err := net.SplitHostPort(u.Host); err != nil {
+			return nil, fmt.Errorf(`URL address does not have the form "host:port": %s`, in)
+		}
+		if u.Path != "" {
+			return nil, fmt.Errorf("URL must not contain a path: %s", in)
+		}
+		all[i] = *u
+	}
+	us := URLs(all)
+	us.Sort()
+
+	return us, nil
+}
+
+func (us URLs) String() string {
+	return strings.Join(us.StringSlice(), ",")
+}
+
+func (us *URLs) Sort() {
+	sort.Sort(us)
+}
+func (us URLs) Len() int           { return len(us) }
+func (us URLs) Less(i, j int) bool { return us[i].String() < us[j].String() }
+func (us URLs) Swap(i, j int)      { us[i], us[j] = us[j], us[i] }
+
+func (us URLs) StringSlice() []string {
+	out := make([]string, len(us))
+	for i := range us {
+		out[i] = us[i].String()
+	}
+
+	return out
+}

--- a/vendor/github.com/coreos/etcd/pkg/types/urls_test.go
+++ b/vendor/github.com/coreos/etcd/pkg/types/urls_test.go
@@ -1,0 +1,169 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/coreos/etcd/pkg/testutil"
+)
+
+func TestNewURLs(t *testing.T) {
+	tests := []struct {
+		strs  []string
+		wurls URLs
+	}{
+		{
+			[]string{"http://127.0.0.1:2379"},
+			testutil.MustNewURLs(t, []string{"http://127.0.0.1:2379"}),
+		},
+		// it can trim space
+		{
+			[]string{"   http://127.0.0.1:2379    "},
+			testutil.MustNewURLs(t, []string{"http://127.0.0.1:2379"}),
+		},
+		// it does sort
+		{
+			[]string{
+				"http://127.0.0.2:2379",
+				"http://127.0.0.1:2379",
+			},
+			testutil.MustNewURLs(t, []string{
+				"http://127.0.0.1:2379",
+				"http://127.0.0.2:2379",
+			}),
+		},
+	}
+	for i, tt := range tests {
+		urls, _ := NewURLs(tt.strs)
+		if !reflect.DeepEqual(urls, tt.wurls) {
+			t.Errorf("#%d: urls = %+v, want %+v", i, urls, tt.wurls)
+		}
+	}
+}
+
+func TestURLsString(t *testing.T) {
+	tests := []struct {
+		us   URLs
+		wstr string
+	}{
+		{
+			URLs{},
+			"",
+		},
+		{
+			testutil.MustNewURLs(t, []string{"http://127.0.0.1:2379"}),
+			"http://127.0.0.1:2379",
+		},
+		{
+			testutil.MustNewURLs(t, []string{
+				"http://127.0.0.1:2379",
+				"http://127.0.0.2:2379",
+			}),
+			"http://127.0.0.1:2379,http://127.0.0.2:2379",
+		},
+		{
+			testutil.MustNewURLs(t, []string{
+				"http://127.0.0.2:2379",
+				"http://127.0.0.1:2379",
+			}),
+			"http://127.0.0.2:2379,http://127.0.0.1:2379",
+		},
+	}
+	for i, tt := range tests {
+		g := tt.us.String()
+		if g != tt.wstr {
+			t.Errorf("#%d: string = %s, want %s", i, g, tt.wstr)
+		}
+	}
+}
+
+func TestURLsSort(t *testing.T) {
+	g := testutil.MustNewURLs(t, []string{
+		"http://127.0.0.4:2379",
+		"http://127.0.0.2:2379",
+		"http://127.0.0.1:2379",
+		"http://127.0.0.3:2379",
+	})
+	w := testutil.MustNewURLs(t, []string{
+		"http://127.0.0.1:2379",
+		"http://127.0.0.2:2379",
+		"http://127.0.0.3:2379",
+		"http://127.0.0.4:2379",
+	})
+	gurls := URLs(g)
+	gurls.Sort()
+	if !reflect.DeepEqual(g, w) {
+		t.Errorf("URLs after sort = %#v, want %#v", g, w)
+	}
+}
+
+func TestURLsStringSlice(t *testing.T) {
+	tests := []struct {
+		us   URLs
+		wstr []string
+	}{
+		{
+			URLs{},
+			[]string{},
+		},
+		{
+			testutil.MustNewURLs(t, []string{"http://127.0.0.1:2379"}),
+			[]string{"http://127.0.0.1:2379"},
+		},
+		{
+			testutil.MustNewURLs(t, []string{
+				"http://127.0.0.1:2379",
+				"http://127.0.0.2:2379",
+			}),
+			[]string{"http://127.0.0.1:2379", "http://127.0.0.2:2379"},
+		},
+		{
+			testutil.MustNewURLs(t, []string{
+				"http://127.0.0.2:2379",
+				"http://127.0.0.1:2379",
+			}),
+			[]string{"http://127.0.0.2:2379", "http://127.0.0.1:2379"},
+		},
+	}
+	for i, tt := range tests {
+		g := tt.us.StringSlice()
+		if !reflect.DeepEqual(g, tt.wstr) {
+			t.Errorf("#%d: string slice = %+v, want %+v", i, g, tt.wstr)
+		}
+	}
+}
+
+func TestNewURLsFail(t *testing.T) {
+	tests := [][]string{
+		// no urls given
+		{},
+		// missing protocol scheme
+		{"://127.0.0.1:2379"},
+		// unsupported scheme
+		{"mailto://127.0.0.1:2379"},
+		// not conform to host:port
+		{"http://127.0.0.1"},
+		// contain a path
+		{"http://127.0.0.1:2379/path"},
+	}
+	for i, tt := range tests {
+		_, err := NewURLs(tt)
+		if err == nil {
+			t.Errorf("#%d: err = nil, but error", i)
+		}
+	}
+}

--- a/vendor/github.com/coreos/etcd/pkg/types/urlsmap.go
+++ b/vendor/github.com/coreos/etcd/pkg/types/urlsmap.go
@@ -1,0 +1,75 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"fmt"
+	"net/url"
+	"sort"
+	"strings"
+)
+
+type URLsMap map[string]URLs
+
+// NewURLsMap returns a URLsMap instantiated from the given string,
+// which consists of discovery-formatted names-to-URLs, like:
+// mach0=http://1.1.1.1:2380,mach0=http://2.2.2.2::2380,mach1=http://3.3.3.3:2380,mach2=http://4.4.4.4:2380
+func NewURLsMap(s string) (URLsMap, error) {
+	cl := URLsMap{}
+	v, err := url.ParseQuery(strings.Replace(s, ",", "&", -1))
+	if err != nil {
+		return nil, err
+	}
+	for name, urls := range v {
+		if len(urls) == 0 || urls[0] == "" {
+			return nil, fmt.Errorf("empty URL given for %q", name)
+		}
+		us, err := NewURLs(urls)
+		if err != nil {
+			return nil, err
+		}
+		cl[name] = us
+	}
+	return cl, nil
+}
+
+// String returns NameURLPairs into discovery-formatted name-to-URLs sorted by name.
+func (c URLsMap) String() string {
+	pairs := make([]string, 0)
+	for name, urls := range c {
+		for _, url := range urls {
+			pairs = append(pairs, fmt.Sprintf("%s=%s", name, url.String()))
+		}
+	}
+	sort.Strings(pairs)
+	return strings.Join(pairs, ",")
+}
+
+// URLs returns a list of all URLs.
+// The returned list is sorted in ascending lexicographical order.
+func (c URLsMap) URLs() []string {
+	urls := make([]string, 0)
+	for _, us := range c {
+		for _, u := range us {
+			urls = append(urls, u.String())
+		}
+	}
+	sort.Strings(urls)
+	return urls
+}
+
+func (c URLsMap) Len() int {
+	return len(c)
+}

--- a/vendor/github.com/coreos/etcd/pkg/types/urlsmap_test.go
+++ b/vendor/github.com/coreos/etcd/pkg/types/urlsmap_test.go
@@ -1,0 +1,69 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/coreos/etcd/pkg/testutil"
+)
+
+func TestParseInitialCluster(t *testing.T) {
+	c, err := NewURLsMap("mem1=http://10.0.0.1:2379,mem1=http://128.193.4.20:2379,mem2=http://10.0.0.2:2379,default=http://127.0.0.1:2379")
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+	wc := URLsMap(map[string]URLs{
+		"mem1":    testutil.MustNewURLs(t, []string{"http://10.0.0.1:2379", "http://128.193.4.20:2379"}),
+		"mem2":    testutil.MustNewURLs(t, []string{"http://10.0.0.2:2379"}),
+		"default": testutil.MustNewURLs(t, []string{"http://127.0.0.1:2379"}),
+	})
+	if !reflect.DeepEqual(c, wc) {
+		t.Errorf("cluster = %+v, want %+v", c, wc)
+	}
+}
+
+func TestParseInitialClusterBad(t *testing.T) {
+	tests := []string{
+		// invalid URL
+		"%^",
+		// no URL defined for member
+		"mem1=,mem2=http://128.193.4.20:2379,mem3=http://10.0.0.2:2379",
+		"mem1,mem2=http://128.193.4.20:2379,mem3=http://10.0.0.2:2379",
+		// bad URL for member
+		"default=http://localhost/",
+	}
+	for i, tt := range tests {
+		if _, err := NewURLsMap(tt); err == nil {
+			t.Errorf("#%d: unexpected successful parse, want err", i)
+		}
+	}
+}
+
+func TestNameURLPairsString(t *testing.T) {
+	cls := URLsMap(map[string]URLs{
+		"abc": testutil.MustNewURLs(t, []string{"http://1.1.1.1:1111", "http://0.0.0.0:0000"}),
+		"def": testutil.MustNewURLs(t, []string{"http://2.2.2.2:2222"}),
+		"ghi": testutil.MustNewURLs(t, []string{"http://3.3.3.3:1234", "http://127.0.0.1:2380"}),
+		// no PeerURLs = not included
+		"four": testutil.MustNewURLs(t, []string{}),
+		"five": testutil.MustNewURLs(t, nil),
+	})
+	w := "abc=http://0.0.0.0:0000,abc=http://1.1.1.1:1111,def=http://2.2.2.2:2222,ghi=http://127.0.0.1:2380,ghi=http://3.3.3.3:1234"
+	if g := cls.String(); g != w {
+		t.Fatalf("NameURLPairs.String():\ngot  %#v\nwant %#v", g, w)
+	}
+}

--- a/vendor/github.com/docker/libkv/.travis.yml
+++ b/vendor/github.com/docker/libkv/.travis.yml
@@ -1,0 +1,34 @@
+language: go
+
+go:
+  - 1.3
+#  - 1.4
+# see https://github.com/moovweb/gvm/pull/116 for why Go 1.4 is currently disabled
+
+# let us have speedy Docker-based Travis workers
+sudo: false
+
+before_install:
+  # Symlink below is needed for Travis CI to work correctly on personal forks of libkv
+  - ln -s $HOME/gopath/src/github.com/${TRAVIS_REPO_SLUG///libkv/} $HOME/gopath/src/github.com/docker
+  - go get golang.org/x/tools/cmd/vet
+  - go get golang.org/x/tools/cmd/cover
+  - go get github.com/mattn/goveralls
+  - go get github.com/golang/lint/golint
+  - go get github.com/GeertJohan/fgt
+
+before_script:
+  - script/travis_consul.sh 0.5.2 
+  - script/travis_etcd.sh 2.2.0
+  - script/travis_zk.sh 3.4.6
+
+script:
+  - ./consul agent -server -bootstrap-expect 1 -data-dir /tmp/consul -config-file=./config.json 1>/dev/null &
+  - ./etcd/etcd --listen-client-urls 'http://0.0.0.0:4001' --advertise-client-urls 'http://127.0.0.1:4001' >/dev/null 2>&1 &
+  - ./zk/bin/zkServer.sh start ./zk/conf/zoo.cfg 1> /dev/null
+  - script/validate-gofmt
+  - go vet ./...
+  - fgt golint ./...
+  - go test -v -race ./...
+  - script/coverage
+  - goveralls -service=travis-ci -coverprofile=goverage.report

--- a/vendor/github.com/docker/libkv/LICENSE.code
+++ b/vendor/github.com/docker/libkv/LICENSE.code
@@ -1,0 +1,191 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2014-2015 Docker, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/docker/libkv/LICENSE.docs
+++ b/vendor/github.com/docker/libkv/LICENSE.docs
@@ -1,0 +1,425 @@
+Attribution-ShareAlike 4.0 International
+
+=======================================================================
+
+Creative Commons Corporation ("Creative Commons") is not a law firm and
+does not provide legal services or legal advice. Distribution of
+Creative Commons public licenses does not create a lawyer-client or
+other relationship. Creative Commons makes its licenses and related
+information available on an "as-is" basis. Creative Commons gives no
+warranties regarding its licenses, any material licensed under their
+terms and conditions, or any related information. Creative Commons
+disclaims all liability for damages resulting from their use to the
+fullest extent possible.
+
+Using Creative Commons Public Licenses
+
+Creative Commons public licenses provide a standard set of terms and
+conditions that creators and other rights holders may use to share
+original works of authorship and other material subject to copyright
+and certain other rights specified in the public license below. The
+following considerations are for informational purposes only, are not
+exhaustive, and do not form part of our licenses.
+
+     Considerations for licensors: Our public licenses are
+     intended for use by those authorized to give the public
+     permission to use material in ways otherwise restricted by
+     copyright and certain other rights. Our licenses are
+     irrevocable. Licensors should read and understand the terms
+     and conditions of the license they choose before applying it.
+     Licensors should also secure all rights necessary before
+     applying our licenses so that the public can reuse the
+     material as expected. Licensors should clearly mark any
+     material not subject to the license. This includes other CC-
+     licensed material, or material used under an exception or
+     limitation to copyright. More considerations for licensors:
+	wiki.creativecommons.org/Considerations_for_licensors
+
+     Considerations for the public: By using one of our public
+     licenses, a licensor grants the public permission to use the
+     licensed material under specified terms and conditions. If
+     the licensor's permission is not necessary for any reason--for
+     example, because of any applicable exception or limitation to
+     copyright--then that use is not regulated by the license. Our
+     licenses grant only permissions under copyright and certain
+     other rights that a licensor has authority to grant. Use of
+     the licensed material may still be restricted for other
+     reasons, including because others have copyright or other
+     rights in the material. A licensor may make special requests,
+     such as asking that all changes be marked or described.
+     Although not required by our licenses, you are encouraged to
+     respect those requests where reasonable. More_considerations
+     for the public:
+	wiki.creativecommons.org/Considerations_for_licensees
+
+=======================================================================
+
+Creative Commons Attribution-ShareAlike 4.0 International Public
+License
+
+By exercising the Licensed Rights (defined below), You accept and agree
+to be bound by the terms and conditions of this Creative Commons
+Attribution-ShareAlike 4.0 International Public License ("Public
+License"). To the extent this Public License may be interpreted as a
+contract, You are granted the Licensed Rights in consideration of Your
+acceptance of these terms and conditions, and the Licensor grants You
+such rights in consideration of benefits the Licensor receives from
+making the Licensed Material available under these terms and
+conditions.
+
+
+Section 1 -- Definitions.
+
+  a. Adapted Material means material subject to Copyright and Similar
+     Rights that is derived from or based upon the Licensed Material
+     and in which the Licensed Material is translated, altered,
+     arranged, transformed, or otherwise modified in a manner requiring
+     permission under the Copyright and Similar Rights held by the
+     Licensor. For purposes of this Public License, where the Licensed
+     Material is a musical work, performance, or sound recording,
+     Adapted Material is always produced where the Licensed Material is
+     synched in timed relation with a moving image.
+
+  b. Adapter's License means the license You apply to Your Copyright
+     and Similar Rights in Your contributions to Adapted Material in
+     accordance with the terms and conditions of this Public License.
+
+  c. BY-SA Compatible License means a license listed at
+     creativecommons.org/compatiblelicenses, approved by Creative
+     Commons as essentially the equivalent of this Public License.
+
+  d. Copyright and Similar Rights means copyright and/or similar rights
+     closely related to copyright including, without limitation,
+     performance, broadcast, sound recording, and Sui Generis Database
+     Rights, without regard to how the rights are labeled or
+     categorized. For purposes of this Public License, the rights
+     specified in Section 2(b)(1)-(2) are not Copyright and Similar
+     Rights.
+
+  e. Effective Technological Measures means those measures that, in the
+     absence of proper authority, may not be circumvented under laws
+     fulfilling obligations under Article 11 of the WIPO Copyright
+     Treaty adopted on December 20, 1996, and/or similar international
+     agreements.
+
+  f. Exceptions and Limitations means fair use, fair dealing, and/or
+     any other exception or limitation to Copyright and Similar Rights
+     that applies to Your use of the Licensed Material.
+
+  g. License Elements means the license attributes listed in the name
+     of a Creative Commons Public License. The License Elements of this
+     Public License are Attribution and ShareAlike.
+
+  h. Licensed Material means the artistic or literary work, database,
+     or other material to which the Licensor applied this Public
+     License.
+
+  i. Licensed Rights means the rights granted to You subject to the
+     terms and conditions of this Public License, which are limited to
+     all Copyright and Similar Rights that apply to Your use of the
+     Licensed Material and that the Licensor has authority to license.
+
+  j. Licensor means the individual(s) or entity(ies) granting rights
+     under this Public License.
+
+  k. Share means to provide material to the public by any means or
+     process that requires permission under the Licensed Rights, such
+     as reproduction, public display, public performance, distribution,
+     dissemination, communication, or importation, and to make material
+     available to the public including in ways that members of the
+     public may access the material from a place and at a time
+     individually chosen by them.
+
+  l. Sui Generis Database Rights means rights other than copyright
+     resulting from Directive 96/9/EC of the European Parliament and of
+     the Council of 11 March 1996 on the legal protection of databases,
+     as amended and/or succeeded, as well as other essentially
+     equivalent rights anywhere in the world.
+
+  m. You means the individual or entity exercising the Licensed Rights
+     under this Public License. Your has a corresponding meaning.
+
+
+Section 2 -- Scope.
+
+  a. License grant.
+
+       1. Subject to the terms and conditions of this Public License,
+          the Licensor hereby grants You a worldwide, royalty-free,
+          non-sublicensable, non-exclusive, irrevocable license to
+          exercise the Licensed Rights in the Licensed Material to:
+
+            a. reproduce and Share the Licensed Material, in whole or
+               in part; and
+
+            b. produce, reproduce, and Share Adapted Material.
+
+       2. Exceptions and Limitations. For the avoidance of doubt, where
+          Exceptions and Limitations apply to Your use, this Public
+          License does not apply, and You do not need to comply with
+          its terms and conditions.
+
+       3. Term. The term of this Public License is specified in Section
+          6(a).
+
+       4. Media and formats; technical modifications allowed. The
+          Licensor authorizes You to exercise the Licensed Rights in
+          all media and formats whether now known or hereafter created,
+          and to make technical modifications necessary to do so. The
+          Licensor waives and/or agrees not to assert any right or
+          authority to forbid You from making technical modifications
+          necessary to exercise the Licensed Rights, including
+          technical modifications necessary to circumvent Effective
+          Technological Measures. For purposes of this Public License,
+          simply making modifications authorized by this Section 2(a)
+          (4) never produces Adapted Material.
+
+       5. Downstream recipients.
+
+            a. Offer from the Licensor -- Licensed Material. Every
+               recipient of the Licensed Material automatically
+               receives an offer from the Licensor to exercise the
+               Licensed Rights under the terms and conditions of this
+               Public License.
+
+            b. Additional offer from the Licensor -- Adapted Material.
+               Every recipient of Adapted Material from You
+               automatically receives an offer from the Licensor to
+               exercise the Licensed Rights in the Adapted Material
+               under the conditions of the Adapter's License You apply.
+
+            c. No downstream restrictions. You may not offer or impose
+               any additional or different terms or conditions on, or
+               apply any Effective Technological Measures to, the
+               Licensed Material if doing so restricts exercise of the
+               Licensed Rights by any recipient of the Licensed
+               Material.
+
+       6. No endorsement. Nothing in this Public License constitutes or
+          may be construed as permission to assert or imply that You
+          are, or that Your use of the Licensed Material is, connected
+          with, or sponsored, endorsed, or granted official status by,
+          the Licensor or others designated to receive attribution as
+          provided in Section 3(a)(1)(A)(i).
+
+  b. Other rights.
+
+       1. Moral rights, such as the right of integrity, are not
+          licensed under this Public License, nor are publicity,
+          privacy, and/or other similar personality rights; however, to
+          the extent possible, the Licensor waives and/or agrees not to
+          assert any such rights held by the Licensor to the limited
+          extent necessary to allow You to exercise the Licensed
+          Rights, but not otherwise.
+
+       2. Patent and trademark rights are not licensed under this
+          Public License.
+
+       3. To the extent possible, the Licensor waives any right to
+          collect royalties from You for the exercise of the Licensed
+          Rights, whether directly or through a collecting society
+          under any voluntary or waivable statutory or compulsory
+          licensing scheme. In all other cases the Licensor expressly
+          reserves any right to collect such royalties.
+
+
+Section 3 -- License Conditions.
+
+Your exercise of the Licensed Rights is expressly made subject to the
+following conditions.
+
+  a. Attribution.
+
+       1. If You Share the Licensed Material (including in modified
+          form), You must:
+
+            a. retain the following if it is supplied by the Licensor
+               with the Licensed Material:
+
+                 i. identification of the creator(s) of the Licensed
+                    Material and any others designated to receive
+                    attribution, in any reasonable manner requested by
+                    the Licensor (including by pseudonym if
+                    designated);
+
+                ii. a copyright notice;
+
+               iii. a notice that refers to this Public License;
+
+                iv. a notice that refers to the disclaimer of
+                    warranties;
+
+                 v. a URI or hyperlink to the Licensed Material to the
+                    extent reasonably practicable;
+
+            b. indicate if You modified the Licensed Material and
+               retain an indication of any previous modifications; and
+
+            c. indicate the Licensed Material is licensed under this
+               Public License, and include the text of, or the URI or
+               hyperlink to, this Public License.
+
+       2. You may satisfy the conditions in Section 3(a)(1) in any
+          reasonable manner based on the medium, means, and context in
+          which You Share the Licensed Material. For example, it may be
+          reasonable to satisfy the conditions by providing a URI or
+          hyperlink to a resource that includes the required
+          information.
+
+       3. If requested by the Licensor, You must remove any of the
+          information required by Section 3(a)(1)(A) to the extent
+          reasonably practicable.
+
+  b. ShareAlike.
+
+     In addition to the conditions in Section 3(a), if You Share
+     Adapted Material You produce, the following conditions also apply.
+
+       1. The Adapter's License You apply must be a Creative Commons
+          license with the same License Elements, this version or
+          later, or a BY-SA Compatible License.
+
+       2. You must include the text of, or the URI or hyperlink to, the
+          Adapter's License You apply. You may satisfy this condition
+          in any reasonable manner based on the medium, means, and
+          context in which You Share Adapted Material.
+
+       3. You may not offer or impose any additional or different terms
+          or conditions on, or apply any Effective Technological
+          Measures to, Adapted Material that restrict exercise of the
+          rights granted under the Adapter's License You apply.
+
+
+Section 4 -- Sui Generis Database Rights.
+
+Where the Licensed Rights include Sui Generis Database Rights that
+apply to Your use of the Licensed Material:
+
+  a. for the avoidance of doubt, Section 2(a)(1) grants You the right
+     to extract, reuse, reproduce, and Share all or a substantial
+     portion of the contents of the database;
+
+  b. if You include all or a substantial portion of the database
+     contents in a database in which You have Sui Generis Database
+     Rights, then the database in which You have Sui Generis Database
+     Rights (but not its individual contents) is Adapted Material,
+
+     including for purposes of Section 3(b); and
+  c. You must comply with the conditions in Section 3(a) if You Share
+     all or a substantial portion of the contents of the database.
+
+For the avoidance of doubt, this Section 4 supplements and does not
+replace Your obligations under this Public License where the Licensed
+Rights include other Copyright and Similar Rights.
+
+
+Section 5 -- Disclaimer of Warranties and Limitation of Liability.
+
+  a. UNLESS OTHERWISE SEPARATELY UNDERTAKEN BY THE LICENSOR, TO THE
+     EXTENT POSSIBLE, THE LICENSOR OFFERS THE LICENSED MATERIAL AS-IS
+     AND AS-AVAILABLE, AND MAKES NO REPRESENTATIONS OR WARRANTIES OF
+     ANY KIND CONCERNING THE LICENSED MATERIAL, WHETHER EXPRESS,
+     IMPLIED, STATUTORY, OR OTHER. THIS INCLUDES, WITHOUT LIMITATION,
+     WARRANTIES OF TITLE, MERCHANTABILITY, FITNESS FOR A PARTICULAR
+     PURPOSE, NON-INFRINGEMENT, ABSENCE OF LATENT OR OTHER DEFECTS,
+     ACCURACY, OR THE PRESENCE OR ABSENCE OF ERRORS, WHETHER OR NOT
+     KNOWN OR DISCOVERABLE. WHERE DISCLAIMERS OF WARRANTIES ARE NOT
+     ALLOWED IN FULL OR IN PART, THIS DISCLAIMER MAY NOT APPLY TO YOU.
+
+  b. TO THE EXTENT POSSIBLE, IN NO EVENT WILL THE LICENSOR BE LIABLE
+     TO YOU ON ANY LEGAL THEORY (INCLUDING, WITHOUT LIMITATION,
+     NEGLIGENCE) OR OTHERWISE FOR ANY DIRECT, SPECIAL, INDIRECT,
+     INCIDENTAL, CONSEQUENTIAL, PUNITIVE, EXEMPLARY, OR OTHER LOSSES,
+     COSTS, EXPENSES, OR DAMAGES ARISING OUT OF THIS PUBLIC LICENSE OR
+     USE OF THE LICENSED MATERIAL, EVEN IF THE LICENSOR HAS BEEN
+     ADVISED OF THE POSSIBILITY OF SUCH LOSSES, COSTS, EXPENSES, OR
+     DAMAGES. WHERE A LIMITATION OF LIABILITY IS NOT ALLOWED IN FULL OR
+     IN PART, THIS LIMITATION MAY NOT APPLY TO YOU.
+
+  c. The disclaimer of warranties and limitation of liability provided
+     above shall be interpreted in a manner that, to the extent
+     possible, most closely approximates an absolute disclaimer and
+     waiver of all liability.
+
+
+Section 6 -- Term and Termination.
+
+  a. This Public License applies for the term of the Copyright and
+     Similar Rights licensed here. However, if You fail to comply with
+     this Public License, then Your rights under this Public License
+     terminate automatically.
+
+  b. Where Your right to use the Licensed Material has terminated under
+     Section 6(a), it reinstates:
+
+       1. automatically as of the date the violation is cured, provided
+          it is cured within 30 days of Your discovery of the
+          violation; or
+
+       2. upon express reinstatement by the Licensor.
+
+     For the avoidance of doubt, this Section 6(b) does not affect any
+     right the Licensor may have to seek remedies for Your violations
+     of this Public License.
+
+  c. For the avoidance of doubt, the Licensor may also offer the
+     Licensed Material under separate terms or conditions or stop
+     distributing the Licensed Material at any time; however, doing so
+     will not terminate this Public License.
+
+  d. Sections 1, 5, 6, 7, and 8 survive termination of this Public
+     License.
+
+
+Section 7 -- Other Terms and Conditions.
+
+  a. The Licensor shall not be bound by any additional or different
+     terms or conditions communicated by You unless expressly agreed.
+
+  b. Any arrangements, understandings, or agreements regarding the
+     Licensed Material not stated herein are separate from and
+     independent of the terms and conditions of this Public License.
+
+
+Section 8 -- Interpretation.
+
+  a. For the avoidance of doubt, this Public License does not, and
+     shall not be interpreted to, reduce, limit, restrict, or impose
+     conditions on any use of the Licensed Material that could lawfully
+     be made without permission under this Public License.
+
+  b. To the extent possible, if any provision of this Public License is
+     deemed unenforceable, it shall be automatically reformed to the
+     minimum extent necessary to make it enforceable. If the provision
+     cannot be reformed, it shall be severed from this Public License
+     without affecting the enforceability of the remaining terms and
+     conditions.
+
+  c. No term or condition of this Public License will be waived and no
+     failure to comply consented to unless expressly agreed to by the
+     Licensor.
+
+  d. Nothing in this Public License constitutes or may be interpreted
+     as a limitation upon, or waiver of, any privileges and immunities
+     that apply to the Licensor or You, including from the legal
+     processes of any jurisdiction or authority.
+
+
+=======================================================================
+
+Creative Commons is not a party to its public licenses.
+Notwithstanding, Creative Commons may elect to apply one of its public
+licenses to material it publishes and in those instances will be
+considered the "Licensor." Except for the limited purpose of indicating
+that material is shared under a Creative Commons public license or as
+otherwise permitted by the Creative Commons policies published at
+creativecommons.org/policies, Creative Commons does not authorize the
+use of the trademark "Creative Commons" or any other trademark or logo
+of Creative Commons without its prior written consent including,
+without limitation, in connection with any unauthorized modifications
+to any of its public licenses or any other arrangements,
+understandings, or agreements concerning use of licensed material. For
+the avoidance of doubt, this paragraph does not form part of the public
+licenses.
+
+Creative Commons may be contacted at creativecommons.org.

--- a/vendor/github.com/docker/libkv/README.md
+++ b/vendor/github.com/docker/libkv/README.md
@@ -1,0 +1,106 @@
+# libkv
+
+[![GoDoc](https://godoc.org/github.com/docker/libkv?status.png)](https://godoc.org/github.com/docker/libkv)
+[![Build Status](https://travis-ci.org/docker/libkv.svg?branch=master)](https://travis-ci.org/docker/libkv)
+[![Coverage Status](https://coveralls.io/repos/docker/libkv/badge.svg)](https://coveralls.io/r/docker/libkv)
+
+`libkv` provides a `Go` native library to store metadata.
+
+The goal of `libkv` is to abstract common store operations for multiple distributed and/or local Key/Value store backends.
+
+For example, you can use it to store your metadata or for service discovery to register machines and endpoints inside your cluster.
+
+You can also easily implement a generic *Leader Election* on top of it (see the [swarm/leadership](https://github.com/docker/swarm/tree/master/leadership) package).
+
+As of now, `libkv` offers support for `Consul`, `Etcd`, `Zookeeper` (**Distributed** store) and `BoltDB` (**Local** store).
+
+## Usage
+
+`libkv` is meant to be used as an abstraction layer over existing distributed Key/Value stores. It is especially useful if you plan to support `consul`, `etcd` and `zookeeper` using the same codebase.
+
+It is ideal if you plan for something written in Go that should support:
+
+- A simple metadata storage, distributed or local
+- A lightweight discovery service for your nodes
+- A distributed lock mechanism
+
+You can find examples of usage for `libkv` under in `docs/examples.go`. Optionally you can also take a look at the `docker/swarm` or `docker/libnetwork` repositories which are using `docker/libkv` for all the use cases listed above.
+
+## Supported versions
+
+`libkv` supports:
+- Consul versions >= `0.5.1` because it uses Sessions with `Delete` behavior for the use of `TTLs` (mimics zookeeper's Ephemeral node support), If you don't plan to use `TTLs`: you can use Consul version `0.4.0+`.
+- Etcd versions >= `2.0` because it uses the new `coreos/etcd/client`, this might change in the future as the support for `APIv3` comes along and adds mor capabilities.
+- Zookeeper versions >= `3.4.5`. Although this might work with previous version but this remains untested as of now.
+- Boltdb, which shouldn't be subject to any version dependencies.
+
+## Interface
+
+A **storage backend** in `libkv` should implement (fully or partially) this interface:
+
+```go
+type Store interface {
+	Put(key string, value []byte, options *WriteOptions) error
+	Get(key string) (*KVPair, error)
+	Delete(key string) error
+	Exists(key string) (bool, error)
+	Watch(key string, stopCh <-chan struct{}) (<-chan *KVPair, error)
+	WatchTree(directory string, stopCh <-chan struct{}) (<-chan []*KVPair, error)
+	NewLock(key string, options *LockOptions) (Locker, error)
+	List(directory string) ([]*KVPair, error)
+	DeleteTree(directory string) error
+	AtomicPut(key string, value []byte, previous *KVPair, options *WriteOptions) (bool, *KVPair, error)
+	AtomicDelete(key string, previous *KVPair) (bool, error)
+	Close()
+}
+```
+
+## Compatibility matrix
+
+Backend drivers in `libkv` are generally divided between **local drivers** and **distributed drivers**. Distributed backends offer enhanced capabilities like `Watches` and/or distributed `Locks`.
+
+Local drivers are usually used in complement to the distributed drivers to store informations that only needs to be available locally.
+
+| Calls                 |   Consul   |  Etcd  |  Zookeeper  |  BoltDB  |
+|-----------------------|:----------:|:------:|:-----------:|:--------:|
+| Put                   |     X      |   X    |      X      |    X     |
+| Get                   |     X      |   X    |      X      |    X     |
+| Delete                |     X      |   X    |      X      |    X     |
+| Exists                |     X      |   X    |      X      |    X     |
+| Watch                 |     X      |   X    |      X      |          |
+| WatchTree             |     X      |   X    |      X      |          |
+| NewLock (Lock/Unlock) |     X      |   X    |      X      |          |
+| List                  |     X      |   X    |      X      |    X     |
+| DeleteTree            |     X      |   X    |      X      |    X     |
+| AtomicPut             |     X      |   X    |      X      |    X     |
+| Close                 |     X      |   X    |      X      |    X     |
+
+## Limitations
+
+Distributed Key/Value stores often have different concepts for managing and formatting keys and their associated values. Even though `libkv` tries to abstract those stores aiming for some consistency, in some cases it can't be applied easily.
+
+Please refer to the `docs/compatibility.md` to see what are the special cases for cross-backend compatibility.
+
+Other than those special cases, you should expect the same experience for basic operations like `Get`/`Put`, etc.
+
+Calls like `WatchTree` may return different events (or number of events) depending on the backend (for now, `Etcd` and `Consul` will likely return more events than `Zookeeper` that you should triage properly). Although you should be able to use it successfully to watch on events in an interchangeable way (see the **swarm/leadership** or **swarm/discovery** packages in **docker/swarm**).
+
+## TLS
+
+Only `Consul` and `etcd` have support for TLS and you should build and provide your own `config.TLS` object to feed the client. Support is planned for `zookeeper`.
+
+##Roadmap
+
+- Make the API nicer to use (using `options`)
+- Provide more options (`consistency` for example)
+- Improve performance (remove extras `Get`/`List` operations)
+- Better key formatting
+- New backends?
+
+##Contributing
+
+Want to hack on libkv? [Docker's contributions guidelines](https://github.com/docker/docker/blob/master/CONTRIBUTING.md) apply.
+
+##Copyright and license
+
+Copyright © 2014-2015 Docker, Inc. All rights reserved, except as follows. Code is released under the Apache 2.0 license. The README.md file, and files in the "docs" folder are licensed under the Creative Commons Attribution 4.0 International License under the terms and conditions set forth in the file "LICENSE.docs". You may obtain a duplicate copy of the same license, titled CC-BY-SA-4.0, at http://creativecommons.org/licenses/by/4.0/.

--- a/vendor/github.com/docker/libkv/docs/compatibility.md
+++ b/vendor/github.com/docker/libkv/docs/compatibility.md
@@ -1,0 +1,82 @@
+#Cross-Backend Compatibility
+
+The value of `libkv` is not to duplicate the code for programs that should support multiple distributed K/V stores like the classic `Consul`/`etcd`/`zookeeper` trio.
+
+This document provides with general guidelines for users willing to support those backends with the same code using `libkv`.
+
+Please note that most of those workarounds are going to disappear in the future with `etcd` APIv3.
+
+##Etcd directory/key distinction
+
+`etcd` with APIv2 makes the distinction between keys and directories. The result with `libkv` is that when using the etcd driver:
+
+- You cannot store values on directories
+- You cannot invoke `WatchTree` (watching on child values), on a regular key
+
+This is fundamentaly different than `Consul` and `zookeeper` which are more permissive and allow the same set of operations on keys and directories (called a Node for zookeeper).
+
+Apiv3 is in the work for `etcd`, which removes this key/directory distinction, but until then you should follow these workarounds to make your `libkv` code work across backends.
+
+###Put
+
+`etcd` cannot put values on directories, so this puts a major restriction compared to `Consul` and `zookeeper`.
+
+If you want to support all those three backends, you should make sure to only put data on **leaves**.
+
+For example:
+
+```go
+_ := kv.Put("path/to/key/bis", []byte("foo"), nil)
+_ := kv.Put("path/to/key", []byte("bar"), nil)
+```
+
+Will work on `Consul` and `zookeeper` but fail for `etcd`. This is because the first `Put` in the case of `etcd` will recursively create the directory hierarchy and `path/to/key` is now considered as a directory. Thus, values should always be stored on leaves if the support for the three backends is planned.
+
+###WatchTree
+
+When initializing the `WatchTree`, the natural way to do so is through the following code:
+
+```go
+key := "path/to/key"
+if !kv.Exists(key) {
+    err := kv.Put(key, []byte("data"), nil)
+}
+events, err := kv.WatchTree(key, nil)
+```
+
+The code above will not work across backends and etcd will fail on the `WatchTree` call. What happens exactly:
+
+- `Consul` will create a regular `key` because it has no distinction between directories and keys. This is not an issue as we can invoke `WatchTree` on regular keys.
+- `zookeeper` is going to create a `node` that can either be a directory or a key during the lifetime of a program but it does not matter as a directory can hold values and be watchable like a regular key.
+- `etcd` is going to create a regular `key`. We cannot invoke `WatchTree` on regular keys using etcd.
+
+To be cross-compatible between those three backends for `WatchTree`, we need to enforce a parameter that is only interpreted with `etcd` and which tells the client to create a `directory` instead of a key.
+
+```go
+key := "path/to/key"
+if !kv.Exists(key) {
+    // We enforce IsDir = true to make sure etcd creates a directory
+    err := kv.Put(key, []byte("data"), &store.WriteOptions{IsDir:true})
+}
+events, err := kv.WatchTree(key, nil)
+```
+
+The code above will work for the three backends but make sure to not try to store any value at that path as the call to `Put` will fail for `etcd` (you can only put at `path/to/key/foo`, `path/to/key/bar` for example).
+
+##Etcd distributed locking
+
+There is `Lock` mechanisms baked in the `coreos/etcd/client` for now. Instead, `libkv` has its own implementation of a `Lock` on top of `etcd`.
+
+The general workflow for the `Lock` is as follows:
+
+- Call Lock concurrently on a `key` between threads/programs
+- Only one will create that key, others are going to fail because the key has already been created
+- The thread locking the key can get the right index to set the value of the key using Compare And Swap and effectively Lock and hold the key
+- Other threads are given a wrong index to fail the Compare and Swap and block until the key has been released by the thread holding the Lock
+- Lock seekers are setting up a Watch listening on that key and events happening on the key
+- When the thread/program stops holding the lock, it deletes the key triggering a `delete` event that will notify all the other threads. In case the program crashes, the key has a TTL attached that will send an `expire` event when this TTL expires.
+- Once everyone is notified, back to the first step. First come, first served with the Lock.
+
+The whole Lock process is highly dependent on the `delete`/`expire` events of `etcd`. So don't expect the key to be still there once the Lock is released.
+
+For example if the whole logic is to `Lock` a key and expect the value to still be there after it has been unlocked, it is not going to be cross-backend compatible with `Consul` and `zookeeper`. On the other end the `etcd` Lock can still be used to do Leader Election for example and still be cross-compatible with other backends.

--- a/vendor/github.com/docker/libkv/docs/examples.md
+++ b/vendor/github.com/docker/libkv/docs/examples.md
@@ -1,0 +1,157 @@
+#Examples
+
+This document contains useful example of usage for `libkv`. It might not be complete but provides with general informations on how to use the client.
+
+##Create a store and use Put/Get/Delete
+
+```go
+package main
+
+import (
+    "fmt"
+    "time"
+    "log"
+
+    "github.com/docker/libkv"
+    "github.com/docker/libkv/store"
+    "github.com/docker/libkv/store/consul"
+)
+
+func init() {
+    // Register consul store to libkv
+    consul.Register()
+
+    // We can register as many backends that are supported by libkv
+    etcd.Register()
+    zookeeper.Register()
+    boltdb.Register()
+}
+
+func main() {
+    client := "localhost:8500"
+
+    // Initialize a new store with consul
+    kv, err := libkv.NewStore(
+        store.CONSUL, // or "consul"
+        []string{client},
+        &store.Config{
+            ConnectionTimeout: 10*time.Second,
+        },
+    )
+    if err != nil {
+        log.Fatal("Cannot create store consul")
+    }
+
+    key := "foo"
+    err = kv.Put(key, []byte("bar"), nil)
+    if err != nil {
+        fmt.Errorf("Error trying to put value at key: %v", key)
+    }
+
+    pair, err := kv.Get(key)
+    if err != nil {
+        fmt.Errorf("Error trying accessing value at key: %v", key)
+    }
+
+    err = kv.Delete(key)
+    if err != nil {
+        fmt.Errorf("Error trying to delete key %v", key)
+    }
+
+    log.Info("value: ", string(pair.Value))
+}
+```
+
+##List keys
+
+```go
+// List will list all the keys under `key` if it contains a set of child keys/values
+entries, err := kv.List(key)
+for _, pair := range entries {
+    fmt.Printf("key=%v - value=%v", pair.Key, string(pair.Value))
+}
+
+```
+
+##Watching for events on a single key (Watch)
+
+You can use watches to watch modifications on a key. First you need to check if the key exists. If this is not the case, we need to create it using the `Put` function.
+
+```go
+// Checking on the key before watching
+if !kv.Exists(key) {
+    err := kv.Put(key, []byte("bar"), nil)
+    if err != nil {
+        fmt.Errorf("Something went wrong when initializing key %v", key)
+    }
+}
+
+stopCh := make(<-chan struct{})
+events, err := kv.Watch(key, stopCh)
+
+select {
+    case pair := <-events:
+        // Do something with events
+        fmt.Printf("value changed on key %v: new value=%v", key, pair.Value)
+}
+
+```
+
+##Watching for events happening on child keys (WatchTree)
+
+You can use watches to watch modifications on a key. First you need to check if the key exists. If this is not the case, we need to create it using the `Put` function. There is a special step here though if you want your code to work across backends. Because `etcd` is a special case and it makes the distinction between directories and keys, we need to make sure that the created key is considered as a directory by enforcing `IsDir` at `true`.
+
+```go
+// Checking on the key before watching
+if !kv.Exists(key) {
+    // Don't forget IsDir:true if the code is used cross-backend
+    err := kv.Put(key, []byte("bar"), &store.WriteOptions{IsDir:true})
+    if err != nil {
+        fmt.Errorf("Something went wrong when initializing key %v", key)
+    }
+}
+
+stopCh := make(<-chan struct{})
+events, err := kv.WatchTree(key, stopCh)
+
+select {
+    case pairs := <-events:
+        // Do something with events
+        for _, pair := range pairs {
+            fmt.Printf("value changed on key %v: new value=%v", key, pair.Value)
+        }
+}
+
+```
+
+## Distributed Locking, using Lock/Unlock
+
+```go
+key := "lockKey"
+value := []byte("bar")
+
+// Initialize a distributed lock. TTL is optional, it is here to make sure that
+// the lock is released after the program that is holding the lock ends or crashes
+lock, err := kv.NewLock(key, &store.LockOptions{Value: value, TTL: 2 * time.Second})
+if err != nil {
+    fmt.Errorf("something went wrong when trying to initialize the Lock")
+}
+
+// Try to lock the key, the call to Lock() is blocking
+_, err := lock.Lock(nil)
+if err != nil {
+    fmt.Errorf("something went wrong when trying to lock key %v", key)
+}
+
+// Get should work because we are holding the key
+pair, err := kv.Get(key)
+if err != nil {
+    fmt.Errorf("key %v has value %v", key, pair.Value)
+}
+
+// Unlock the key
+err = lock.Unlock()
+if err != nil {
+    fmt.Errorf("something went wrong when trying to unlock key %v", key)
+}
+```

--- a/vendor/github.com/docker/libkv/libkv.go
+++ b/vendor/github.com/docker/libkv/libkv.go
@@ -1,0 +1,40 @@
+package libkv
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/docker/libkv/store"
+)
+
+// Initialize creates a new Store object, initializing the client
+type Initialize func(addrs []string, options *store.Config) (store.Store, error)
+
+var (
+	// Backend initializers
+	initializers = make(map[store.Backend]Initialize)
+
+	supportedBackend = func() string {
+		keys := make([]string, 0, len(initializers))
+		for k := range initializers {
+			keys = append(keys, string(k))
+		}
+		sort.Strings(keys)
+		return strings.Join(keys, ", ")
+	}()
+)
+
+// NewStore creates a an instance of store
+func NewStore(backend store.Backend, addrs []string, options *store.Config) (store.Store, error) {
+	if init, exists := initializers[backend]; exists {
+		return init(addrs, options)
+	}
+
+	return nil, fmt.Errorf("%s %s", store.ErrBackendNotSupported.Error(), supportedBackend)
+}
+
+// AddStore adds a new store backend to libkv
+func AddStore(store store.Backend, init Initialize) {
+	initializers[store] = init
+}

--- a/vendor/github.com/docker/libkv/libkv_test.go
+++ b/vendor/github.com/docker/libkv/libkv_test.go
@@ -1,0 +1,24 @@
+package libkv
+
+import (
+	"testing"
+	"time"
+
+	"github.com/docker/libkv/store"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewStoreUnsupported(t *testing.T) {
+	client := "localhost:9999"
+
+	kv, err := NewStore(
+		"unsupported",
+		[]string{client},
+		&store.Config{
+			ConnectionTimeout: 10 * time.Second,
+		},
+	)
+	assert.Error(t, err)
+	assert.Nil(t, kv)
+	assert.Equal(t, "Backend storage not supported yet, please choose one of ", err.Error())
+}

--- a/vendor/github.com/docker/libkv/script/.validate
+++ b/vendor/github.com/docker/libkv/script/.validate
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+if [ -z "$VALIDATE_UPSTREAM" ]; then
+	# this is kind of an expensive check, so let's not do this twice if we
+	# are running more than one validate bundlescript
+	
+	VALIDATE_REPO='https://github.com/docker/libkv.git'
+	VALIDATE_BRANCH='master'
+	
+	if [ "$TRAVIS" = 'true' -a "$TRAVIS_PULL_REQUEST" != 'false' ]; then
+		VALIDATE_REPO="https://github.com/${TRAVIS_REPO_SLUG}.git"
+		VALIDATE_BRANCH="${TRAVIS_BRANCH}"
+	fi
+	
+	VALIDATE_HEAD="$(git rev-parse --verify HEAD)"
+	
+	git fetch -q "$VALIDATE_REPO" "refs/heads/$VALIDATE_BRANCH"
+	VALIDATE_UPSTREAM="$(git rev-parse --verify FETCH_HEAD)"
+	
+	VALIDATE_COMMIT_LOG="$VALIDATE_UPSTREAM..$VALIDATE_HEAD"
+	VALIDATE_COMMIT_DIFF="$VALIDATE_UPSTREAM...$VALIDATE_HEAD"
+	
+	validate_diff() {
+		if [ "$VALIDATE_UPSTREAM" != "$VALIDATE_HEAD" ]; then
+			git diff "$VALIDATE_COMMIT_DIFF" "$@"
+		fi
+	}
+	validate_log() {
+		if [ "$VALIDATE_UPSTREAM" != "$VALIDATE_HEAD" ]; then
+			git log "$VALIDATE_COMMIT_LOG" "$@"
+		fi
+	}
+fi

--- a/vendor/github.com/docker/libkv/script/coverage
+++ b/vendor/github.com/docker/libkv/script/coverage
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+MODE="mode: count"
+ROOT=${TRAVIS_BUILD_DIR:-.}/../../..
+
+# Grab the list of packages.
+# Exclude the API and CLI from coverage as it will be covered by integration tests.
+PACKAGES=`go list ./...`
+
+# Create the empty coverage file.
+echo $MODE > goverage.report
+
+# Run coverage on every package.
+for package in $PACKAGES; do
+	output="$ROOT/$package/coverage.out"
+
+	go test -test.short -covermode=count -coverprofile=$output $package
+	if [ -f "$output" ] ; then
+		cat "$output" | grep -v "$MODE" >> goverage.report
+	fi
+done

--- a/vendor/github.com/docker/libkv/script/travis_consul.sh
+++ b/vendor/github.com/docker/libkv/script/travis_consul.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+if [  $# -gt 0 ] ; then
+    CONSUL_VERSION="$1"
+else
+    CONSUL_VERSION="0.5.2"
+fi
+
+# install consul
+wget "https://dl.bintray.com/mitchellh/consul/${CONSUL_VERSION}_linux_amd64.zip"
+unzip "${CONSUL_VERSION}_linux_amd64.zip"
+
+# make config for minimum ttl
+touch config.json
+echo "{\"session_ttl_min\": \"1s\"}" >> config.json
+
+# check
+./consul --version

--- a/vendor/github.com/docker/libkv/script/travis_etcd.sh
+++ b/vendor/github.com/docker/libkv/script/travis_etcd.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+if [  $# -gt 0 ] ; then
+    ETCD_VERSION="$1"
+else
+    ETCD_VERSION="2.2.0"
+fi
+
+curl -L https://github.com/coreos/etcd/releases/download/v$ETCD_VERSION/etcd-v$ETCD_VERSION-linux-amd64.tar.gz -o etcd-v$ETCD_VERSION-linux-amd64.tar.gz
+tar xzvf etcd-v$ETCD_VERSION-linux-amd64.tar.gz
+mv etcd-v$ETCD_VERSION-linux-amd64 etcd

--- a/vendor/github.com/docker/libkv/script/travis_zk.sh
+++ b/vendor/github.com/docker/libkv/script/travis_zk.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+if [  $# -gt 0 ] ; then
+    ZK_VERSION="$1"
+else
+    ZK_VERSION="3.4.6"
+fi
+
+wget "http://mirrors.ukfast.co.uk/sites/ftp.apache.org/zookeeper/stable/zookeeper-${ZK_VERSION}.tar.gz"
+tar -xvf "zookeeper-${ZK_VERSION}.tar.gz"
+mv zookeeper-$ZK_VERSION zk
+mv ./zk/conf/zoo_sample.cfg ./zk/conf/zoo.cfg

--- a/vendor/github.com/docker/libkv/script/validate-gofmt
+++ b/vendor/github.com/docker/libkv/script/validate-gofmt
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+source "$(dirname "$BASH_SOURCE")/.validate"
+
+IFS=$'\n'
+files=( $(validate_diff --diff-filter=ACMR --name-only -- '*.go' | grep -v '^Godeps/' || true) )
+unset IFS
+
+badFiles=()
+for f in "${files[@]}"; do
+	# we use "git show" here to validate that what's committed is formatted
+	if [ "$(git show "$VALIDATE_HEAD:$f" | gofmt -s -l)" ]; then
+		badFiles+=( "$f" )
+	fi
+done
+
+if [ ${#badFiles[@]} -eq 0 ]; then
+	echo 'Congratulations!  All Go source files are properly formatted.'
+else
+	{
+		echo "These files are not properly gofmt'd:"
+		for f in "${badFiles[@]}"; do
+			echo " - $f"
+		done
+		echo
+		echo 'Please reformat the above files using "gofmt -s -w" and commit the result.'
+		echo
+	} >&2
+	false
+fi

--- a/vendor/github.com/docker/libkv/store/boltdb/boltdb.go
+++ b/vendor/github.com/docker/libkv/store/boltdb/boltdb.go
@@ -1,0 +1,442 @@
+package boltdb
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"time"
+
+	"github.com/boltdb/bolt"
+	"github.com/docker/libkv"
+	"github.com/docker/libkv/store"
+)
+
+var (
+	// ErrMultipleEndpointsUnsupported is thrown when multiple endpoints specified for
+	// BoltDB. Endpoint has to be a local file path
+	ErrMultipleEndpointsUnsupported = errors.New("boltdb supports one endpoint and should be a file path")
+	// ErrBoltBucketNotFound is thrown when specified BoltBD bucket doesn't exist in the DB
+	ErrBoltBucketNotFound = errors.New("boltdb bucket doesn't exist")
+	// ErrBoltBucketOptionMissing is thrown when boltBcuket config option is missing
+	ErrBoltBucketOptionMissing = errors.New("boltBucket config option missing")
+)
+
+const (
+	filePerm os.FileMode = 0644
+)
+
+//BoltDB type implements the Store interface
+type BoltDB struct {
+	client     *bolt.DB
+	boltBucket []byte
+	dbIndex    uint64
+	path       string
+	timeout    time.Duration
+	// By default libkv opens and closes the bolt DB connection  for every
+	// get/put operation. This allows multiple apps to use a Bolt DB at the
+	// same time.
+	// PersistConnection flag provides an option to override ths behavior.
+	// ie: open the connection in New and use it till Close is called.
+	PersistConnection bool
+}
+
+const (
+	libkvmetadatalen = 8
+	transientTimeout = time.Duration(10) * time.Second
+)
+
+// Register registers boltdb to libkv
+func Register() {
+	libkv.AddStore(store.BOLTDB, New)
+}
+
+// New opens a new BoltDB connection to the specified path and bucket
+func New(endpoints []string, options *store.Config) (store.Store, error) {
+	var (
+		db          *bolt.DB
+		err         error
+		boltOptions *bolt.Options
+	)
+
+	if len(endpoints) > 1 {
+		return nil, ErrMultipleEndpointsUnsupported
+	}
+
+	if (options == nil) || (len(options.Bucket) == 0) {
+		return nil, ErrBoltBucketOptionMissing
+	}
+
+	dir, _ := filepath.Split(endpoints[0])
+	if err = os.MkdirAll(dir, 0750); err != nil {
+		return nil, err
+	}
+
+	if options.PersistConnection {
+		boltOptions = &bolt.Options{Timeout: options.ConnectionTimeout}
+		db, err = bolt.Open(endpoints[0], filePerm, boltOptions)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	b := &BoltDB{
+		client:            db,
+		path:              endpoints[0],
+		boltBucket:        []byte(options.Bucket),
+		timeout:           transientTimeout,
+		PersistConnection: options.PersistConnection,
+	}
+
+	return b, nil
+}
+
+func (b *BoltDB) reset() {
+	b.path = ""
+	b.boltBucket = []byte{}
+}
+
+func (b *BoltDB) getDBhandle() (*bolt.DB, error) {
+	var (
+		db  *bolt.DB
+		err error
+	)
+	if !b.PersistConnection {
+		boltOptions := &bolt.Options{Timeout: b.timeout}
+		if db, err = bolt.Open(b.path, filePerm, boltOptions); err != nil {
+			return nil, err
+		}
+		b.client = db
+	}
+
+	return b.client, nil
+}
+
+func (b *BoltDB) releaseDBhandle() {
+	if !b.PersistConnection {
+		b.client.Close()
+	}
+}
+
+// Get the value at "key". BoltDB doesn't provide an inbuilt last modified index with every kv pair. Its implemented by
+// by a atomic counter maintained by the libkv and appened to the value passed by the client.
+func (b *BoltDB) Get(key string) (*store.KVPair, error) {
+	var (
+		val []byte
+		db  *bolt.DB
+		err error
+	)
+
+	if db, err = b.getDBhandle(); err != nil {
+		return nil, err
+	}
+	defer b.releaseDBhandle()
+
+	err = db.View(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket(b.boltBucket)
+		if bucket == nil {
+			return ErrBoltBucketNotFound
+		}
+
+		v := bucket.Get([]byte(key))
+		val = make([]byte, len(v))
+		copy(val, v)
+
+		return nil
+	})
+
+	if len(val) == 0 {
+		return nil, store.ErrKeyNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	dbIndex := binary.LittleEndian.Uint64(val[:libkvmetadatalen])
+	val = val[libkvmetadatalen:]
+
+	return &store.KVPair{Key: key, Value: val, LastIndex: (dbIndex)}, nil
+}
+
+//Put the key, value pair. index number metadata is prepended to the value
+func (b *BoltDB) Put(key string, value []byte, opts *store.WriteOptions) error {
+	var (
+		dbIndex uint64
+		db      *bolt.DB
+		err     error
+	)
+	dbval := make([]byte, libkvmetadatalen)
+
+	if db, err = b.getDBhandle(); err != nil {
+		return err
+	}
+	defer b.releaseDBhandle()
+
+	err = db.Update(func(tx *bolt.Tx) error {
+		bucket, err := tx.CreateBucketIfNotExists(b.boltBucket)
+		if err != nil {
+			return err
+		}
+
+		dbIndex = atomic.AddUint64(&b.dbIndex, 1)
+		binary.LittleEndian.PutUint64(dbval, dbIndex)
+		dbval = append(dbval, value...)
+
+		err = bucket.Put([]byte(key), dbval)
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+	return err
+}
+
+//Delete the value for the given key.
+func (b *BoltDB) Delete(key string) error {
+	var (
+		db  *bolt.DB
+		err error
+	)
+	if db, err = b.getDBhandle(); err != nil {
+		return err
+	}
+	defer b.releaseDBhandle()
+
+	err = db.Update(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket(b.boltBucket)
+		if bucket == nil {
+			return ErrBoltBucketNotFound
+		}
+		err := bucket.Delete([]byte(key))
+		return err
+	})
+	return err
+}
+
+// Exists checks if the key exists inside the store
+func (b *BoltDB) Exists(key string) (bool, error) {
+	var (
+		val []byte
+		db  *bolt.DB
+		err error
+	)
+
+	if db, err = b.getDBhandle(); err != nil {
+		return false, err
+	}
+	defer b.releaseDBhandle()
+
+	err = db.View(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket(b.boltBucket)
+		if bucket == nil {
+			return ErrBoltBucketNotFound
+		}
+
+		val = bucket.Get([]byte(key))
+
+		return nil
+	})
+
+	if len(val) == 0 {
+		return false, err
+	}
+	return true, err
+}
+
+// List returns the range of keys starting with the passed in prefix
+func (b *BoltDB) List(keyPrefix string) ([]*store.KVPair, error) {
+	var (
+		db  *bolt.DB
+		err error
+	)
+	kv := []*store.KVPair{}
+
+	if db, err = b.getDBhandle(); err != nil {
+		return nil, err
+	}
+	defer b.releaseDBhandle()
+
+	err = db.View(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket(b.boltBucket)
+		if bucket == nil {
+			return ErrBoltBucketNotFound
+		}
+
+		cursor := bucket.Cursor()
+		prefix := []byte(keyPrefix)
+
+		for key, v := cursor.Seek(prefix); bytes.HasPrefix(key, prefix); key, v = cursor.Next() {
+
+			dbIndex := binary.LittleEndian.Uint64(v[:libkvmetadatalen])
+			v = v[libkvmetadatalen:]
+			val := make([]byte, len(v))
+			copy(val, v)
+
+			kv = append(kv, &store.KVPair{
+				Key:       string(key),
+				Value:     val,
+				LastIndex: dbIndex,
+			})
+		}
+		return nil
+	})
+	if len(kv) == 0 {
+		return nil, store.ErrKeyNotFound
+	}
+	return kv, err
+}
+
+// AtomicDelete deletes a value at "key" if the key
+// has not been modified in the meantime, throws an
+// error if this is the case
+func (b *BoltDB) AtomicDelete(key string, previous *store.KVPair) (bool, error) {
+	var (
+		val []byte
+		db  *bolt.DB
+		err error
+	)
+
+	if previous == nil {
+		return false, store.ErrPreviousNotSpecified
+	}
+	if db, err = b.getDBhandle(); err != nil {
+		return false, err
+	}
+	defer b.releaseDBhandle()
+
+	err = db.Update(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket(b.boltBucket)
+		if bucket == nil {
+			return ErrBoltBucketNotFound
+		}
+
+		val = bucket.Get([]byte(key))
+		dbIndex := binary.LittleEndian.Uint64(val[:libkvmetadatalen])
+		if dbIndex != previous.LastIndex {
+			return store.ErrKeyModified
+		}
+		err := bucket.Delete([]byte(key))
+		return err
+	})
+	if err != nil {
+		return false, err
+	}
+	return true, err
+}
+
+// AtomicPut puts a value at "key" if the key has not been
+// modified since the last Put, throws an error if this is the case
+func (b *BoltDB) AtomicPut(key string, value []byte, previous *store.KVPair, options *store.WriteOptions) (bool, *store.KVPair, error) {
+	var (
+		val     []byte
+		dbIndex uint64
+		db      *bolt.DB
+		err     error
+	)
+	dbval := make([]byte, libkvmetadatalen)
+
+	if db, err = b.getDBhandle(); err != nil {
+		return false, nil, err
+	}
+	defer b.releaseDBhandle()
+
+	err = db.Update(func(tx *bolt.Tx) error {
+		var err error
+		bucket := tx.Bucket(b.boltBucket)
+		if bucket == nil {
+			if previous != nil {
+				return ErrBoltBucketNotFound
+			}
+			bucket, err = tx.CreateBucket(b.boltBucket)
+			if err != nil {
+				return err
+			}
+		}
+		// AtomicPut is equivalent to Put if previous is nil and the Ky
+		// doesn't exist in the DB.
+		val = bucket.Get([]byte(key))
+		if previous == nil && len(val) != 0 {
+			return store.ErrKeyModified
+		}
+		if previous != nil {
+			if len(val) == 0 {
+				return store.ErrKeyNotFound
+			}
+			dbIndex = binary.LittleEndian.Uint64(val[:libkvmetadatalen])
+			if dbIndex != previous.LastIndex {
+				return store.ErrKeyModified
+			}
+		}
+		dbIndex = atomic.AddUint64(&b.dbIndex, 1)
+		binary.LittleEndian.PutUint64(dbval, b.dbIndex)
+		dbval = append(dbval, value...)
+		return (bucket.Put([]byte(key), dbval))
+	})
+	if err != nil {
+		return false, nil, err
+	}
+
+	updated := &store.KVPair{
+		Key:       key,
+		Value:     value,
+		LastIndex: dbIndex,
+	}
+
+	return true, updated, nil
+}
+
+// Close the db connection to the BoltDB
+func (b *BoltDB) Close() {
+	if !b.PersistConnection {
+		b.reset()
+	} else {
+		b.client.Close()
+	}
+	return
+}
+
+// DeleteTree deletes a range of keys with a given prefix
+func (b *BoltDB) DeleteTree(keyPrefix string) error {
+	var (
+		db  *bolt.DB
+		err error
+	)
+	if db, err = b.getDBhandle(); err != nil {
+		return err
+	}
+	defer b.releaseDBhandle()
+
+	err = db.Update(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket(b.boltBucket)
+		if bucket == nil {
+			return ErrBoltBucketNotFound
+		}
+
+		cursor := bucket.Cursor()
+		prefix := []byte(keyPrefix)
+
+		for key, _ := cursor.Seek(prefix); bytes.HasPrefix(key, prefix); key, _ = cursor.Next() {
+			_ = bucket.Delete([]byte(key))
+		}
+		return nil
+	})
+
+	return err
+}
+
+// NewLock has to implemented at the library level since its not supported by BoltDB
+func (b *BoltDB) NewLock(key string, options *store.LockOptions) (store.Locker, error) {
+	return nil, store.ErrCallNotSupported
+}
+
+// Watch has to implemented at the library level since its not supported by BoltDB
+func (b *BoltDB) Watch(key string, stopCh <-chan struct{}) (<-chan *store.KVPair, error) {
+	return nil, store.ErrCallNotSupported
+}
+
+// WatchTree has to implemented at the library level since its not supported by BoltDB
+func (b *BoltDB) WatchTree(directory string, stopCh <-chan struct{}) (<-chan []*store.KVPair, error) {
+	return nil, store.ErrCallNotSupported
+}

--- a/vendor/github.com/docker/libkv/store/boltdb/boltdb_test.go
+++ b/vendor/github.com/docker/libkv/store/boltdb/boltdb_test.go
@@ -1,0 +1,144 @@
+package boltdb
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/docker/libkv"
+	"github.com/docker/libkv/store"
+	"github.com/docker/libkv/testutils"
+	"github.com/stretchr/testify/assert"
+)
+
+func makeBoltDBClient(t *testing.T) store.Store {
+	kv, err := New([]string{"/tmp/not_exist_dir/__boltdbtest"}, &store.Config{Bucket: "boltDBTest"})
+
+	if err != nil {
+		t.Fatalf("cannot create store: %v", err)
+	}
+
+	return kv
+}
+
+func TestRegister(t *testing.T) {
+	Register()
+
+	kv, err := libkv.NewStore(
+		store.BOLTDB,
+		[]string{"/tmp/not_exist_dir/__boltdbtest"},
+		&store.Config{Bucket: "boltDBTest"},
+	)
+	assert.NoError(t, err)
+	assert.NotNil(t, kv)
+
+	if _, ok := kv.(*BoltDB); !ok {
+		t.Fatal("Error registering and initializing boltDB")
+	}
+
+	_ = os.Remove("/tmp/not_exist_dir/__boltdbtest")
+}
+
+// TestMultiplePersistConnection tests the second connection to a
+// BoltDB fails when one is already open with PersistConnection flag
+func TestMultiplePersistConnection(t *testing.T) {
+	kv, err := libkv.NewStore(
+		store.BOLTDB,
+		[]string{"/tmp/not_exist_dir/__boltdbtest"},
+		&store.Config{
+			Bucket:            "boltDBTest",
+			ConnectionTimeout: 1 * time.Second,
+			PersistConnection: true},
+	)
+	assert.NoError(t, err)
+	assert.NotNil(t, kv)
+
+	if _, ok := kv.(*BoltDB); !ok {
+		t.Fatal("Error registering and initializing boltDB")
+	}
+
+	// Must fail if multiple boltdb requests are made with a valid timeout
+	kv, err = libkv.NewStore(
+		store.BOLTDB,
+		[]string{"/tmp/not_exist_dir/__boltdbtest"},
+		&store.Config{
+			Bucket:            "boltDBTest",
+			ConnectionTimeout: 1 * time.Second,
+			PersistConnection: true},
+	)
+	assert.Error(t, err)
+
+	_ = os.Remove("/tmp/not_exist_dir/__boltdbtest")
+}
+
+// TestConcurrentConnection tests simultaenous get/put using
+// two handles.
+func TestConcurrentConnection(t *testing.T) {
+	var err error
+	kv1, err1 := libkv.NewStore(
+		store.BOLTDB,
+		[]string{"/tmp/__boltdbtest"},
+		&store.Config{
+			Bucket:            "boltDBTest",
+			ConnectionTimeout: 1 * time.Second},
+	)
+	assert.NoError(t, err1)
+	assert.NotNil(t, kv1)
+
+	kv2, err2 := libkv.NewStore(
+		store.BOLTDB,
+		[]string{"/tmp/__boltdbtest"},
+		&store.Config{Bucket: "boltDBTest",
+			ConnectionTimeout: 1 * time.Second},
+	)
+	assert.NoError(t, err2)
+	assert.NotNil(t, kv2)
+
+	key1 := "TestKV1"
+	value1 := []byte("TestVal1")
+	err = kv1.Put(key1, value1, nil)
+	assert.NoError(t, err)
+
+	key2 := "TestKV2"
+	value2 := []byte("TestVal2")
+	err = kv2.Put(key2, value2, nil)
+	assert.NoError(t, err)
+
+	pair1, err1 := kv1.Get(key1)
+	assert.NoError(t, err)
+	if assert.NotNil(t, pair1) {
+		assert.NotNil(t, pair1.Value)
+	}
+	assert.Equal(t, pair1.Value, value1)
+
+	pair2, err2 := kv2.Get(key2)
+	assert.NoError(t, err)
+	if assert.NotNil(t, pair2) {
+		assert.NotNil(t, pair2.Value)
+	}
+	assert.Equal(t, pair2.Value, value2)
+
+	// AtomicPut using kv1 and kv2 should succeed
+	_, _, err = kv1.AtomicPut(key1, []byte("TestnewVal1"), pair1, nil)
+	assert.NoError(t, err)
+
+	_, _, err = kv2.AtomicPut(key2, []byte("TestnewVal2"), pair2, nil)
+	assert.NoError(t, err)
+
+	testutils.RunTestCommon(t, kv1)
+	testutils.RunTestCommon(t, kv2)
+
+	kv1.Close()
+	kv2.Close()
+
+	_ = os.Remove("/tmp/__boltdbtest")
+}
+
+func TestBoldDBStore(t *testing.T) {
+	kv := makeBoltDBClient(t)
+
+	testutils.RunTestCommon(t, kv)
+	testutils.RunTestAtomic(t, kv)
+
+	_ = os.Remove("/tmp/not_exist_dir/__boltdbtest")
+}

--- a/vendor/github.com/docker/libkv/store/consul/consul.go
+++ b/vendor/github.com/docker/libkv/store/consul/consul.go
@@ -1,0 +1,471 @@
+package consul
+
+import (
+	"crypto/tls"
+	"errors"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/docker/libkv"
+	"github.com/docker/libkv/store"
+	api "github.com/hashicorp/consul/api"
+)
+
+const (
+	// DefaultWatchWaitTime is how long we block for at a
+	// time to check if the watched key has changed. This
+	// affects the minimum time it takes to cancel a watch.
+	DefaultWatchWaitTime = 15 * time.Second
+)
+
+var (
+	// ErrMultipleEndpointsUnsupported is thrown when there are
+	// multiple endpoints specified for Consul
+	ErrMultipleEndpointsUnsupported = errors.New("consul does not support multiple endpoints")
+)
+
+// Consul is the receiver type for the
+// Store interface
+type Consul struct {
+	sync.Mutex
+	config *api.Config
+	client *api.Client
+}
+
+type consulLock struct {
+	lock    *api.Lock
+	renewCh chan struct{}
+}
+
+// Register registers consul to libkv
+func Register() {
+	libkv.AddStore(store.CONSUL, New)
+}
+
+// New creates a new Consul client given a list
+// of endpoints and optional tls config
+func New(endpoints []string, options *store.Config) (store.Store, error) {
+	if len(endpoints) > 1 {
+		return nil, ErrMultipleEndpointsUnsupported
+	}
+
+	s := &Consul{}
+
+	// Create Consul client
+	config := api.DefaultConfig()
+	s.config = config
+	config.HttpClient = http.DefaultClient
+	config.Address = endpoints[0]
+	config.Scheme = "http"
+
+	// Set options
+	if options != nil {
+		if options.TLS != nil {
+			s.setTLS(options.TLS)
+		}
+		if options.ConnectionTimeout != 0 {
+			s.setTimeout(options.ConnectionTimeout)
+		}
+	}
+
+	// Creates a new client
+	client, err := api.NewClient(config)
+	if err != nil {
+		return nil, err
+	}
+	s.client = client
+
+	return s, nil
+}
+
+// SetTLS sets Consul TLS options
+func (s *Consul) setTLS(tls *tls.Config) {
+	s.config.HttpClient.Transport = &http.Transport{
+		TLSClientConfig: tls,
+	}
+	s.config.Scheme = "https"
+}
+
+// SetTimeout sets the timeout for connecting to Consul
+func (s *Consul) setTimeout(time time.Duration) {
+	s.config.WaitTime = time
+}
+
+// Normalize the key for usage in Consul
+func (s *Consul) normalize(key string) string {
+	key = store.Normalize(key)
+	return strings.TrimPrefix(key, "/")
+}
+
+func (s *Consul) refreshSession(pair *api.KVPair, ttl time.Duration) error {
+	// Check if there is any previous session with an active TTL
+	session, err := s.getActiveSession(pair.Key)
+	if err != nil {
+		return err
+	}
+
+	if session == "" {
+		entry := &api.SessionEntry{
+			Behavior:  api.SessionBehaviorDelete, // Delete the key when the session expires
+			TTL:       (ttl / 2).String(),        // Consul multiplies the TTL by 2x
+			LockDelay: 1 * time.Millisecond,      // Virtually disable lock delay
+		}
+
+		// Create the key session
+		session, _, err = s.client.Session().Create(entry, nil)
+		if err != nil {
+			return err
+		}
+
+		lockOpts := &api.LockOptions{
+			Key:     pair.Key,
+			Session: session,
+		}
+
+		// Lock and ignore if lock is held
+		// It's just a placeholder for the
+		// ephemeral behavior
+		lock, _ := s.client.LockOpts(lockOpts)
+		if lock != nil {
+			lock.Lock(nil)
+		}
+	}
+
+	_, _, err = s.client.Session().Renew(session, nil)
+	if err != nil {
+		return s.refreshSession(pair, ttl)
+	}
+	return nil
+}
+
+// getActiveSession checks if the key already has
+// a session attached
+func (s *Consul) getActiveSession(key string) (string, error) {
+	pair, _, err := s.client.KV().Get(key, nil)
+	if err != nil {
+		return "", err
+	}
+	if pair != nil && pair.Session != "" {
+		return pair.Session, nil
+	}
+	return "", nil
+}
+
+// Get the value at "key", returns the last modified index
+// to use in conjunction to CAS calls
+func (s *Consul) Get(key string) (*store.KVPair, error) {
+	options := &api.QueryOptions{
+		AllowStale:        false,
+		RequireConsistent: true,
+	}
+
+	pair, meta, err := s.client.KV().Get(s.normalize(key), options)
+	if err != nil {
+		return nil, err
+	}
+
+	// If pair is nil then the key does not exist
+	if pair == nil {
+		return nil, store.ErrKeyNotFound
+	}
+
+	return &store.KVPair{Key: pair.Key, Value: pair.Value, LastIndex: meta.LastIndex}, nil
+}
+
+// Put a value at "key"
+func (s *Consul) Put(key string, value []byte, opts *store.WriteOptions) error {
+	key = s.normalize(key)
+
+	p := &api.KVPair{
+		Key:   key,
+		Value: value,
+	}
+
+	if opts != nil && opts.TTL > 0 {
+		// Create or refresh the session
+		err := s.refreshSession(p, opts.TTL)
+		if err != nil {
+			return err
+		}
+	}
+
+	_, err := s.client.KV().Put(p, nil)
+	return err
+}
+
+// Delete a value at "key"
+func (s *Consul) Delete(key string) error {
+	if _, err := s.Get(key); err != nil {
+		return err
+	}
+	_, err := s.client.KV().Delete(s.normalize(key), nil)
+	return err
+}
+
+// Exists checks that the key exists inside the store
+func (s *Consul) Exists(key string) (bool, error) {
+	_, err := s.Get(key)
+	if err != nil {
+		if err == store.ErrKeyNotFound {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+// List child nodes of a given directory
+func (s *Consul) List(directory string) ([]*store.KVPair, error) {
+	pairs, _, err := s.client.KV().List(s.normalize(directory), nil)
+	if err != nil {
+		return nil, err
+	}
+	if len(pairs) == 0 {
+		return nil, store.ErrKeyNotFound
+	}
+
+	kv := []*store.KVPair{}
+
+	for _, pair := range pairs {
+		if pair.Key == directory {
+			continue
+		}
+		kv = append(kv, &store.KVPair{
+			Key:       pair.Key,
+			Value:     pair.Value,
+			LastIndex: pair.ModifyIndex,
+		})
+	}
+
+	return kv, nil
+}
+
+// DeleteTree deletes a range of keys under a given directory
+func (s *Consul) DeleteTree(directory string) error {
+	if _, err := s.List(directory); err != nil {
+		return err
+	}
+	_, err := s.client.KV().DeleteTree(s.normalize(directory), nil)
+	return err
+}
+
+// Watch for changes on a "key"
+// It returns a channel that will receive changes or pass
+// on errors. Upon creation, the current value will first
+// be sent to the channel. Providing a non-nil stopCh can
+// be used to stop watching.
+func (s *Consul) Watch(key string, stopCh <-chan struct{}) (<-chan *store.KVPair, error) {
+	kv := s.client.KV()
+	watchCh := make(chan *store.KVPair)
+
+	go func() {
+		defer close(watchCh)
+
+		// Use a wait time in order to check if we should quit
+		// from time to time.
+		opts := &api.QueryOptions{WaitTime: DefaultWatchWaitTime}
+
+		for {
+			// Check if we should quit
+			select {
+			case <-stopCh:
+				return
+			default:
+			}
+
+			// Get the key
+			pair, meta, err := kv.Get(key, opts)
+			if err != nil {
+				return
+			}
+
+			// If LastIndex didn't change then it means `Get` returned
+			// because of the WaitTime and the key didn't changed.
+			if opts.WaitIndex == meta.LastIndex {
+				continue
+			}
+			opts.WaitIndex = meta.LastIndex
+
+			// Return the value to the channel
+			// FIXME: What happens when a key is deleted?
+			if pair != nil {
+				watchCh <- &store.KVPair{
+					Key:       pair.Key,
+					Value:     pair.Value,
+					LastIndex: pair.ModifyIndex,
+				}
+			}
+		}
+	}()
+
+	return watchCh, nil
+}
+
+// WatchTree watches for changes on a "directory"
+// It returns a channel that will receive changes or pass
+// on errors. Upon creating a watch, the current childs values
+// will be sent to the channel .Providing a non-nil stopCh can
+// be used to stop watching.
+func (s *Consul) WatchTree(directory string, stopCh <-chan struct{}) (<-chan []*store.KVPair, error) {
+	kv := s.client.KV()
+	watchCh := make(chan []*store.KVPair)
+
+	go func() {
+		defer close(watchCh)
+
+		// Use a wait time in order to check if we should quit
+		// from time to time.
+		opts := &api.QueryOptions{WaitTime: DefaultWatchWaitTime}
+		for {
+			// Check if we should quit
+			select {
+			case <-stopCh:
+				return
+			default:
+			}
+
+			// Get all the childrens
+			pairs, meta, err := kv.List(directory, opts)
+			if err != nil {
+				return
+			}
+
+			// If LastIndex didn't change then it means `Get` returned
+			// because of the WaitTime and the child keys didn't change.
+			if opts.WaitIndex == meta.LastIndex {
+				continue
+			}
+			opts.WaitIndex = meta.LastIndex
+
+			// Return children KV pairs to the channel
+			kvpairs := []*store.KVPair{}
+			for _, pair := range pairs {
+				if pair.Key == directory {
+					continue
+				}
+				kvpairs = append(kvpairs, &store.KVPair{
+					Key:       pair.Key,
+					Value:     pair.Value,
+					LastIndex: pair.ModifyIndex,
+				})
+			}
+			watchCh <- kvpairs
+		}
+	}()
+
+	return watchCh, nil
+}
+
+// NewLock returns a handle to a lock struct which can
+// be used to provide mutual exclusion on a key
+func (s *Consul) NewLock(key string, options *store.LockOptions) (store.Locker, error) {
+	lockOpts := &api.LockOptions{
+		Key: s.normalize(key),
+	}
+
+	lock := &consulLock{}
+
+	if options != nil {
+		// Set optional TTL on Lock
+		if options.TTL != 0 {
+			entry := &api.SessionEntry{
+				Behavior:  api.SessionBehaviorRelease, // Release the lock when the session expires
+				TTL:       (options.TTL / 2).String(), // Consul multiplies the TTL by 2x
+				LockDelay: 1 * time.Millisecond,       // Virtually disable lock delay
+			}
+
+			// Create the key session
+			session, _, err := s.client.Session().Create(entry, nil)
+			if err != nil {
+				return nil, err
+			}
+
+			// Place the session on lock
+			lockOpts.Session = session
+
+			// Renew the session ttl lock periodically
+			go s.client.Session().RenewPeriodic(entry.TTL, session, nil, options.RenewLock)
+			lock.renewCh = options.RenewLock
+		}
+
+		// Set optional value on Lock
+		if options.Value != nil {
+			lockOpts.Value = options.Value
+		}
+	}
+
+	l, err := s.client.LockOpts(lockOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	lock.lock = l
+	return lock, nil
+}
+
+// Lock attempts to acquire the lock and blocks while
+// doing so. It returns a channel that is closed if our
+// lock is lost or if an error occurs
+func (l *consulLock) Lock(stopChan chan struct{}) (<-chan struct{}, error) {
+	return l.lock.Lock(stopChan)
+}
+
+// Unlock the "key". Calling unlock while
+// not holding the lock will throw an error
+func (l *consulLock) Unlock() error {
+	if l.renewCh != nil {
+		close(l.renewCh)
+	}
+	return l.lock.Unlock()
+}
+
+// AtomicPut put a value at "key" if the key has not been
+// modified in the meantime, throws an error if this is the case
+func (s *Consul) AtomicPut(key string, value []byte, previous *store.KVPair, options *store.WriteOptions) (bool, *store.KVPair, error) {
+
+	p := &api.KVPair{Key: s.normalize(key), Value: value}
+
+	if previous == nil {
+		// Consul interprets ModifyIndex = 0 as new key.
+		p.ModifyIndex = 0
+	} else {
+		p.ModifyIndex = previous.LastIndex
+	}
+
+	if work, _, err := s.client.KV().CAS(p, nil); err != nil {
+		return false, nil, err
+	} else if !work {
+		return false, nil, store.ErrKeyModified
+	}
+
+	pair, err := s.Get(key)
+	if err != nil {
+		return false, nil, err
+	}
+
+	return true, pair, nil
+}
+
+// AtomicDelete deletes a value at "key" if the key has not
+// been modified in the meantime, throws an error if this is the case
+func (s *Consul) AtomicDelete(key string, previous *store.KVPair) (bool, error) {
+	if previous == nil {
+		return false, store.ErrPreviousNotSpecified
+	}
+
+	p := &api.KVPair{Key: s.normalize(key), ModifyIndex: previous.LastIndex}
+	if work, _, err := s.client.KV().DeleteCAS(p, nil); err != nil {
+		return false, err
+	} else if !work {
+		return false, store.ErrKeyModified
+	}
+
+	return true, nil
+}
+
+// Close closes the client connection
+func (s *Consul) Close() {
+	return
+}

--- a/vendor/github.com/docker/libkv/store/consul/consul_test.go
+++ b/vendor/github.com/docker/libkv/store/consul/consul_test.go
@@ -1,0 +1,84 @@
+package consul
+
+import (
+	"testing"
+	"time"
+
+	"github.com/docker/libkv"
+	"github.com/docker/libkv/store"
+	"github.com/docker/libkv/testutils"
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	client = "localhost:8500"
+)
+
+func makeConsulClient(t *testing.T) store.Store {
+
+	kv, err := New(
+		[]string{client},
+		&store.Config{
+			ConnectionTimeout: 3 * time.Second,
+		},
+	)
+
+	if err != nil {
+		t.Fatalf("cannot create store: %v", err)
+	}
+
+	return kv
+}
+
+func TestRegister(t *testing.T) {
+	Register()
+
+	kv, err := libkv.NewStore(store.CONSUL, []string{client}, nil)
+	assert.NoError(t, err)
+	assert.NotNil(t, kv)
+
+	if _, ok := kv.(*Consul); !ok {
+		t.Fatal("Error registering and initializing consul")
+	}
+}
+
+func TestConsulStore(t *testing.T) {
+	kv := makeConsulClient(t)
+	lockKV := makeConsulClient(t)
+	ttlKV := makeConsulClient(t)
+
+	testutils.RunTestCommon(t, kv)
+	testutils.RunTestAtomic(t, kv)
+	testutils.RunTestWatch(t, kv)
+	testutils.RunTestLock(t, kv)
+	testutils.RunTestLockTTL(t, kv, lockKV)
+	testutils.RunTestTTL(t, kv, ttlKV)
+	testutils.RunCleanup(t, kv)
+}
+
+func TestGetActiveSession(t *testing.T) {
+	kv := makeConsulClient(t)
+
+	consul := kv.(*Consul)
+
+	key := "foo"
+	value := []byte("bar")
+
+	// Put the first key with the Ephemeral flag
+	err := kv.Put(key, value, &store.WriteOptions{TTL: 2 * time.Second})
+	assert.NoError(t, err)
+
+	// Session should not be empty
+	session, err := consul.getActiveSession(key)
+	assert.NoError(t, err)
+	assert.NotEqual(t, session, "")
+
+	// Delete the key
+	err = kv.Delete(key)
+	assert.NoError(t, err)
+
+	// Check the session again, it should return nothing
+	session, err = consul.getActiveSession(key)
+	assert.NoError(t, err)
+	assert.Equal(t, session, "")
+}

--- a/vendor/github.com/docker/libkv/store/etcd/etcd.go
+++ b/vendor/github.com/docker/libkv/store/etcd/etcd.go
@@ -1,0 +1,589 @@
+package etcd
+
+import (
+	"crypto/tls"
+	"errors"
+	"log"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+
+	"golang.org/x/net/context"
+
+	etcd "github.com/coreos/etcd/client"
+	"github.com/docker/libkv"
+	"github.com/docker/libkv/store"
+)
+
+var (
+	// ErrAbortTryLock is thrown when a user stops trying to seek the lock
+	// by sending a signal to the stop chan, this is used to verify if the
+	// operation succeeded
+	ErrAbortTryLock = errors.New("lock operation aborted")
+)
+
+// Etcd is the receiver type for the
+// Store interface
+type Etcd struct {
+	client etcd.KeysAPI
+}
+
+type etcdLock struct {
+	client    etcd.KeysAPI
+	stopLock  chan struct{}
+	stopRenew chan struct{}
+	key       string
+	value     string
+	last      *etcd.Response
+	ttl       time.Duration
+}
+
+const (
+	periodicSync      = 5 * time.Minute
+	defaultLockTTL    = 20 * time.Second
+	defaultUpdateTime = 5 * time.Second
+)
+
+// Register registers etcd to libkv
+func Register() {
+	libkv.AddStore(store.ETCD, New)
+}
+
+// New creates a new Etcd client given a list
+// of endpoints and an optional tls config
+func New(addrs []string, options *store.Config) (store.Store, error) {
+	s := &Etcd{}
+
+	var (
+		entries []string
+		err     error
+	)
+
+	entries = store.CreateEndpoints(addrs, "http")
+	cfg := &etcd.Config{
+		Endpoints:               entries,
+		Transport:               etcd.DefaultTransport,
+		HeaderTimeoutPerRequest: 3 * time.Second,
+	}
+
+	// Set options
+	if options != nil {
+		if options.TLS != nil {
+			setTLS(cfg, options.TLS, addrs)
+		}
+		if options.ConnectionTimeout != 0 {
+			setTimeout(cfg, options.ConnectionTimeout)
+		}
+	}
+
+	c, err := etcd.New(*cfg)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	s.client = etcd.NewKeysAPI(c)
+
+	// Periodic Cluster Sync
+	go func() {
+		for {
+			if err := c.AutoSync(context.Background(), periodicSync); err != nil {
+				return
+			}
+		}
+	}()
+
+	return s, nil
+}
+
+// SetTLS sets the tls configuration given a tls.Config scheme
+func setTLS(cfg *etcd.Config, tls *tls.Config, addrs []string) {
+	entries := store.CreateEndpoints(addrs, "https")
+	cfg.Endpoints = entries
+
+	// Set transport
+	t := http.Transport{
+		Dial: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).Dial,
+		TLSHandshakeTimeout: 10 * time.Second,
+		TLSClientConfig:     tls,
+	}
+
+	cfg.Transport = &t
+}
+
+// setTimeout sets the timeout used for connecting to the store
+func setTimeout(cfg *etcd.Config, time time.Duration) {
+	cfg.HeaderTimeoutPerRequest = time
+}
+
+// Normalize the key for usage in Etcd
+func (s *Etcd) normalize(key string) string {
+	key = store.Normalize(key)
+	return strings.TrimPrefix(key, "/")
+}
+
+// keyNotFound checks on the error returned by the KeysAPI
+// to verify if the key exists in the store or not
+func keyNotFound(err error) bool {
+	if err != nil {
+		if etcdError, ok := err.(etcd.Error); ok {
+			if etcdError.Code == etcd.ErrorCodeKeyNotFound ||
+				etcdError.Code == etcd.ErrorCodeNotFile ||
+				etcdError.Code == etcd.ErrorCodeNotDir {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// Get the value at "key", returns the last modified
+// index to use in conjunction to Atomic calls
+func (s *Etcd) Get(key string) (pair *store.KVPair, err error) {
+	getOpts := &etcd.GetOptions{
+		Quorum: true,
+	}
+
+	result, err := s.client.Get(context.Background(), s.normalize(key), getOpts)
+	if err != nil {
+		if keyNotFound(err) {
+			return nil, store.ErrKeyNotFound
+		}
+		return nil, err
+	}
+
+	pair = &store.KVPair{
+		Key:       key,
+		Value:     []byte(result.Node.Value),
+		LastIndex: result.Node.ModifiedIndex,
+	}
+
+	return pair, nil
+}
+
+// Put a value at "key"
+func (s *Etcd) Put(key string, value []byte, opts *store.WriteOptions) error {
+	setOpts := &etcd.SetOptions{}
+
+	// Set options
+	if opts != nil {
+		setOpts.Dir = opts.IsDir
+		setOpts.TTL = opts.TTL
+	}
+
+	_, err := s.client.Set(context.Background(), s.normalize(key), string(value), setOpts)
+	return err
+}
+
+// Delete a value at "key"
+func (s *Etcd) Delete(key string) error {
+	opts := &etcd.DeleteOptions{
+		Recursive: false,
+	}
+
+	_, err := s.client.Delete(context.Background(), s.normalize(key), opts)
+	if keyNotFound(err) {
+		return store.ErrKeyNotFound
+	}
+	return err
+}
+
+// Exists checks if the key exists inside the store
+func (s *Etcd) Exists(key string) (bool, error) {
+	_, err := s.Get(key)
+	if err != nil {
+		if err == store.ErrKeyNotFound {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+// Watch for changes on a "key"
+// It returns a channel that will receive changes or pass
+// on errors. Upon creation, the current value will first
+// be sent to the channel. Providing a non-nil stopCh can
+// be used to stop watching.
+func (s *Etcd) Watch(key string, stopCh <-chan struct{}) (<-chan *store.KVPair, error) {
+	opts := &etcd.WatcherOptions{Recursive: false}
+	watcher := s.client.Watcher(s.normalize(key), opts)
+
+	// watchCh is sending back events to the caller
+	watchCh := make(chan *store.KVPair)
+
+	go func() {
+		defer close(watchCh)
+
+		// Get the current value
+		pair, err := s.Get(key)
+		if err != nil {
+			return
+		}
+
+		// Push the current value through the channel.
+		watchCh <- pair
+
+		for {
+			// Check if the watch was stopped by the caller
+			select {
+			case <-stopCh:
+				return
+			default:
+			}
+
+			result, err := watcher.Next(context.Background())
+
+			if err != nil {
+				return
+			}
+
+			watchCh <- &store.KVPair{
+				Key:       key,
+				Value:     []byte(result.Node.Value),
+				LastIndex: result.Node.ModifiedIndex,
+			}
+		}
+	}()
+
+	return watchCh, nil
+}
+
+// WatchTree watches for changes on a "directory"
+// It returns a channel that will receive changes or pass
+// on errors. Upon creating a watch, the current childs values
+// will be sent to the channel. Providing a non-nil stopCh can
+// be used to stop watching.
+func (s *Etcd) WatchTree(directory string, stopCh <-chan struct{}) (<-chan []*store.KVPair, error) {
+	watchOpts := &etcd.WatcherOptions{Recursive: true}
+	watcher := s.client.Watcher(s.normalize(directory), watchOpts)
+
+	// watchCh is sending back events to the caller
+	watchCh := make(chan []*store.KVPair)
+
+	go func() {
+		defer close(watchCh)
+
+		// Get child values
+		list, err := s.List(directory)
+		if err != nil {
+			return
+		}
+
+		// Push the current value through the channel.
+		watchCh <- list
+
+		for {
+			// Check if the watch was stopped by the caller
+			select {
+			case <-stopCh:
+				return
+			default:
+			}
+
+			_, err := watcher.Next(context.Background())
+
+			if err != nil {
+				return
+			}
+
+			list, err = s.List(directory)
+			if err != nil {
+				return
+			}
+
+			watchCh <- list
+		}
+	}()
+
+	return watchCh, nil
+}
+
+// AtomicPut puts a value at "key" if the key has not been
+// modified in the meantime, throws an error if this is the case
+func (s *Etcd) AtomicPut(key string, value []byte, previous *store.KVPair, opts *store.WriteOptions) (bool, *store.KVPair, error) {
+	var (
+		meta *etcd.Response
+		err  error
+	)
+
+	setOpts := &etcd.SetOptions{}
+
+	if previous != nil {
+		setOpts.PrevExist = etcd.PrevExist
+		setOpts.PrevIndex = previous.LastIndex
+		if previous.Value != nil {
+			setOpts.PrevValue = string(previous.Value)
+		}
+	} else {
+		setOpts.PrevExist = etcd.PrevNoExist
+	}
+
+	if opts != nil {
+		if opts.TTL > 0 {
+			setOpts.TTL = opts.TTL
+		}
+	}
+
+	meta, err = s.client.Set(context.Background(), s.normalize(key), string(value), setOpts)
+	if err != nil {
+		if etcdError, ok := err.(etcd.Error); ok {
+			// Compare failed
+			if etcdError.Code == etcd.ErrorCodeTestFailed {
+				return false, nil, store.ErrKeyModified
+			}
+		}
+		return false, nil, err
+	}
+
+	updated := &store.KVPair{
+		Key:       key,
+		Value:     value,
+		LastIndex: meta.Node.ModifiedIndex,
+	}
+
+	return true, updated, nil
+}
+
+// AtomicDelete deletes a value at "key" if the key
+// has not been modified in the meantime, throws an
+// error if this is the case
+func (s *Etcd) AtomicDelete(key string, previous *store.KVPair) (bool, error) {
+	if previous == nil {
+		return false, store.ErrPreviousNotSpecified
+	}
+
+	delOpts := &etcd.DeleteOptions{}
+
+	if previous != nil {
+		delOpts.PrevIndex = previous.LastIndex
+		if previous.Value != nil {
+			delOpts.PrevValue = string(previous.Value)
+		}
+	}
+
+	_, err := s.client.Delete(context.Background(), s.normalize(key), delOpts)
+	if err != nil {
+		if etcdError, ok := err.(etcd.Error); ok {
+			// Compare failed
+			if etcdError.Code == etcd.ErrorCodeTestFailed {
+				return false, store.ErrKeyModified
+			}
+		}
+		return false, err
+	}
+
+	return true, nil
+}
+
+// List child nodes of a given directory
+func (s *Etcd) List(directory string) ([]*store.KVPair, error) {
+	getOpts := &etcd.GetOptions{
+		Quorum:    true,
+		Recursive: true,
+		Sort:      true,
+	}
+
+	resp, err := s.client.Get(context.Background(), s.normalize(directory), getOpts)
+	if err != nil {
+		if keyNotFound(err) {
+			return nil, store.ErrKeyNotFound
+		}
+		return nil, err
+	}
+
+	kv := []*store.KVPair{}
+	for _, n := range resp.Node.Nodes {
+		kv = append(kv, &store.KVPair{
+			Key:       n.Key,
+			Value:     []byte(n.Value),
+			LastIndex: n.ModifiedIndex,
+		})
+	}
+	return kv, nil
+}
+
+// DeleteTree deletes a range of keys under a given directory
+func (s *Etcd) DeleteTree(directory string) error {
+	delOpts := &etcd.DeleteOptions{
+		Recursive: true,
+	}
+
+	_, err := s.client.Delete(context.Background(), s.normalize(directory), delOpts)
+	if keyNotFound(err) {
+		return store.ErrKeyNotFound
+	}
+	return err
+}
+
+// NewLock returns a handle to a lock struct which can
+// be used to provide mutual exclusion on a key
+func (s *Etcd) NewLock(key string, options *store.LockOptions) (lock store.Locker, err error) {
+	var value string
+	ttl := defaultLockTTL
+	renewCh := make(chan struct{})
+
+	// Apply options on Lock
+	if options != nil {
+		if options.Value != nil {
+			value = string(options.Value)
+		}
+		if options.TTL != 0 {
+			ttl = options.TTL
+		}
+		if options.RenewLock != nil {
+			renewCh = options.RenewLock
+		}
+	}
+
+	// Create lock object
+	lock = &etcdLock{
+		client:    s.client,
+		stopRenew: renewCh,
+		key:       s.normalize(key),
+		value:     value,
+		ttl:       ttl,
+	}
+
+	return lock, nil
+}
+
+// Lock attempts to acquire the lock and blocks while
+// doing so. It returns a channel that is closed if our
+// lock is lost or if an error occurs
+func (l *etcdLock) Lock(stopChan chan struct{}) (<-chan struct{}, error) {
+
+	// Lock holder channel
+	lockHeld := make(chan struct{})
+	stopLocking := l.stopRenew
+
+	setOpts := &etcd.SetOptions{
+		TTL: l.ttl,
+	}
+
+	for {
+		setOpts.PrevExist = etcd.PrevNoExist
+		resp, err := l.client.Set(context.Background(), l.key, l.value, setOpts)
+		if err != nil {
+			if etcdError, ok := err.(etcd.Error); ok {
+				if etcdError.Code != etcd.ErrorCodeNodeExist {
+					return nil, err
+				}
+				setOpts.PrevIndex = ^uint64(0)
+			}
+		} else {
+			setOpts.PrevIndex = resp.Node.ModifiedIndex
+		}
+
+		setOpts.PrevExist = etcd.PrevExist
+		l.last, err = l.client.Set(context.Background(), l.key, l.value, setOpts)
+
+		if err == nil {
+			// Leader section
+			l.stopLock = stopLocking
+			go l.holdLock(l.key, lockHeld, stopLocking)
+			break
+		} else {
+			// If this is a legitimate error, return
+			if etcdError, ok := err.(etcd.Error); ok {
+				if etcdError.Code != etcd.ErrorCodeTestFailed {
+					return nil, err
+				}
+			}
+
+			// Seeker section
+			errorCh := make(chan error)
+			chWStop := make(chan bool)
+			free := make(chan bool)
+
+			go l.waitLock(l.key, errorCh, chWStop, free)
+
+			// Wait for the key to be available or for
+			// a signal to stop trying to lock the key
+			select {
+			case _ = <-free:
+				break
+			case err := <-errorCh:
+				return nil, err
+			case _ = <-stopChan:
+				return nil, ErrAbortTryLock
+			}
+
+			// Delete or Expire event occured
+			// Retry
+		}
+	}
+
+	return lockHeld, nil
+}
+
+// Hold the lock as long as we can
+// Updates the key ttl periodically until we receive
+// an explicit stop signal from the Unlock method
+func (l *etcdLock) holdLock(key string, lockHeld chan struct{}, stopLocking <-chan struct{}) {
+	defer close(lockHeld)
+
+	update := time.NewTicker(l.ttl / 3)
+	defer update.Stop()
+
+	var err error
+	setOpts := &etcd.SetOptions{TTL: l.ttl}
+
+	for {
+		select {
+		case <-update.C:
+			setOpts.PrevIndex = l.last.Node.ModifiedIndex
+			l.last, err = l.client.Set(context.Background(), key, l.value, setOpts)
+			if err != nil {
+				return
+			}
+
+		case <-stopLocking:
+			return
+		}
+	}
+}
+
+// WaitLock simply waits for the key to be available for creation
+func (l *etcdLock) waitLock(key string, errorCh chan error, stopWatchCh chan bool, free chan<- bool) {
+	opts := &etcd.WatcherOptions{Recursive: false}
+	watcher := l.client.Watcher(key, opts)
+
+	for {
+		event, err := watcher.Next(context.Background())
+		if err != nil {
+			errorCh <- err
+			return
+		}
+		if event.Action == "delete" || event.Action == "expire" {
+			free <- true
+			return
+		}
+	}
+}
+
+// Unlock the "key". Calling unlock while
+// not holding the lock will throw an error
+func (l *etcdLock) Unlock() error {
+	if l.stopLock != nil {
+		l.stopLock <- struct{}{}
+	}
+	if l.last != nil {
+		delOpts := &etcd.DeleteOptions{
+			PrevIndex: l.last.Node.ModifiedIndex,
+		}
+		_, err := l.client.Delete(context.Background(), l.key, delOpts)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Close closes the client connection
+func (s *Etcd) Close() {
+	return
+}

--- a/vendor/github.com/docker/libkv/store/etcd/etcd_test.go
+++ b/vendor/github.com/docker/libkv/store/etcd/etcd_test.go
@@ -1,0 +1,56 @@
+package etcd
+
+import (
+	"testing"
+	"time"
+
+	"github.com/docker/libkv"
+	"github.com/docker/libkv/store"
+	"github.com/docker/libkv/testutils"
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	client = "localhost:4001"
+)
+
+func makeEtcdClient(t *testing.T) store.Store {
+	kv, err := New(
+		[]string{client},
+		&store.Config{
+			ConnectionTimeout: 3 * time.Second,
+		},
+	)
+
+	if err != nil {
+		t.Fatalf("cannot create store: %v", err)
+	}
+
+	return kv
+}
+
+func TestRegister(t *testing.T) {
+	Register()
+
+	kv, err := libkv.NewStore(store.ETCD, []string{client}, nil)
+	assert.NoError(t, err)
+	assert.NotNil(t, kv)
+
+	if _, ok := kv.(*Etcd); !ok {
+		t.Fatal("Error registering and initializing etcd")
+	}
+}
+
+func TestEtcdStore(t *testing.T) {
+	kv := makeEtcdClient(t)
+	lockKV := makeEtcdClient(t)
+	ttlKV := makeEtcdClient(t)
+
+	testutils.RunTestCommon(t, kv)
+	testutils.RunTestAtomic(t, kv)
+	testutils.RunTestWatch(t, kv)
+	testutils.RunTestLock(t, kv)
+	testutils.RunTestLockTTL(t, kv, lockKV)
+	testutils.RunTestTTL(t, kv, ttlKV)
+	testutils.RunCleanup(t, kv)
+}

--- a/vendor/github.com/docker/libkv/store/helpers.go
+++ b/vendor/github.com/docker/libkv/store/helpers.go
@@ -1,0 +1,47 @@
+package store
+
+import (
+	"strings"
+)
+
+// CreateEndpoints creates a list of endpoints given the right scheme
+func CreateEndpoints(addrs []string, scheme string) (entries []string) {
+	for _, addr := range addrs {
+		entries = append(entries, scheme+"://"+addr)
+	}
+	return entries
+}
+
+// Normalize the key for each store to the form:
+//
+//     /path/to/key
+//
+func Normalize(key string) string {
+	return "/" + join(SplitKey(key))
+}
+
+// GetDirectory gets the full directory part of
+// the key to the form:
+//
+//     /path/to/
+//
+func GetDirectory(key string) string {
+	parts := SplitKey(key)
+	parts = parts[:len(parts)-1]
+	return "/" + join(parts)
+}
+
+// SplitKey splits the key to extract path informations
+func SplitKey(key string) (path []string) {
+	if strings.Contains(key, "/") {
+		path = strings.Split(key, "/")
+	} else {
+		path = []string{key}
+	}
+	return path
+}
+
+// join the path parts with '/'
+func join(parts []string) string {
+	return strings.Join(parts, "/")
+}

--- a/vendor/github.com/docker/libkv/store/mock/mock.go
+++ b/vendor/github.com/docker/libkv/store/mock/mock.go
@@ -1,0 +1,113 @@
+package mock
+
+import (
+	"github.com/docker/libkv/store"
+	"github.com/stretchr/testify/mock"
+)
+
+// Mock store. Mocks all Store functions using testify.Mock
+type Mock struct {
+	mock.Mock
+
+	// Endpoints passed to InitializeMock
+	Endpoints []string
+
+	// Options passed to InitializeMock
+	Options *store.Config
+}
+
+// New creates a Mock store
+func New(endpoints []string, options *store.Config) (store.Store, error) {
+	s := &Mock{}
+	s.Endpoints = endpoints
+	s.Options = options
+	return s, nil
+}
+
+// Put mock
+func (s *Mock) Put(key string, value []byte, opts *store.WriteOptions) error {
+	args := s.Mock.Called(key, value, opts)
+	return args.Error(0)
+}
+
+// Get mock
+func (s *Mock) Get(key string) (*store.KVPair, error) {
+	args := s.Mock.Called(key)
+	return args.Get(0).(*store.KVPair), args.Error(1)
+}
+
+// Delete mock
+func (s *Mock) Delete(key string) error {
+	args := s.Mock.Called(key)
+	return args.Error(0)
+}
+
+// Exists mock
+func (s *Mock) Exists(key string) (bool, error) {
+	args := s.Mock.Called(key)
+	return args.Bool(0), args.Error(1)
+}
+
+// Watch mock
+func (s *Mock) Watch(key string, stopCh <-chan struct{}) (<-chan *store.KVPair, error) {
+	args := s.Mock.Called(key, stopCh)
+	return args.Get(0).(<-chan *store.KVPair), args.Error(1)
+}
+
+// WatchTree mock
+func (s *Mock) WatchTree(prefix string, stopCh <-chan struct{}) (<-chan []*store.KVPair, error) {
+	args := s.Mock.Called(prefix, stopCh)
+	return args.Get(0).(chan []*store.KVPair), args.Error(1)
+}
+
+// NewLock mock
+func (s *Mock) NewLock(key string, options *store.LockOptions) (store.Locker, error) {
+	args := s.Mock.Called(key, options)
+	return args.Get(0).(store.Locker), args.Error(1)
+}
+
+// List mock
+func (s *Mock) List(prefix string) ([]*store.KVPair, error) {
+	args := s.Mock.Called(prefix)
+	return args.Get(0).([]*store.KVPair), args.Error(1)
+}
+
+// DeleteTree mock
+func (s *Mock) DeleteTree(prefix string) error {
+	args := s.Mock.Called(prefix)
+	return args.Error(0)
+}
+
+// AtomicPut mock
+func (s *Mock) AtomicPut(key string, value []byte, previous *store.KVPair, opts *store.WriteOptions) (bool, *store.KVPair, error) {
+	args := s.Mock.Called(key, value, previous, opts)
+	return args.Bool(0), args.Get(1).(*store.KVPair), args.Error(2)
+}
+
+// AtomicDelete mock
+func (s *Mock) AtomicDelete(key string, previous *store.KVPair) (bool, error) {
+	args := s.Mock.Called(key, previous)
+	return args.Bool(0), args.Error(1)
+}
+
+// Lock mock implementation of Locker
+type Lock struct {
+	mock.Mock
+}
+
+// Lock mock
+func (l *Lock) Lock(stopCh chan struct{}) (<-chan struct{}, error) {
+	args := l.Mock.Called(stopCh)
+	return args.Get(0).(<-chan struct{}), args.Error(1)
+}
+
+// Unlock mock
+func (l *Lock) Unlock() error {
+	args := l.Mock.Called()
+	return args.Error(0)
+}
+
+// Close mock
+func (s *Mock) Close() {
+	return
+}

--- a/vendor/github.com/docker/libkv/store/store.go
+++ b/vendor/github.com/docker/libkv/store/store.go
@@ -1,0 +1,128 @@
+package store
+
+import (
+	"crypto/tls"
+	"errors"
+	"time"
+)
+
+// Backend represents a KV Store Backend
+type Backend string
+
+const (
+	// CONSUL backend
+	CONSUL Backend = "consul"
+	// ETCD backend
+	ETCD Backend = "etcd"
+	// ZK backend
+	ZK Backend = "zk"
+	// BOLTDB backend
+	BOLTDB Backend = "boltdb"
+)
+
+var (
+	// ErrBackendNotSupported is thrown when the backend k/v store is not supported by libkv
+	ErrBackendNotSupported = errors.New("Backend storage not supported yet, please choose one of")
+	// ErrCallNotSupported is thrown when a method is not implemented/supported by the current backend
+	ErrCallNotSupported = errors.New("The current call is not supported with this backend")
+	// ErrNotReachable is thrown when the API cannot be reached for issuing common store operations
+	ErrNotReachable = errors.New("Api not reachable")
+	// ErrCannotLock is thrown when there is an error acquiring a lock on a key
+	ErrCannotLock = errors.New("Error acquiring the lock")
+	// ErrKeyModified is thrown during an atomic operation if the index does not match the one in the store
+	ErrKeyModified = errors.New("Unable to complete atomic operation, key modified")
+	// ErrKeyNotFound is thrown when the key is not found in the store during a Get operation
+	ErrKeyNotFound = errors.New("Key not found in store")
+	// ErrPreviousNotSpecified is thrown when the previous value is not specified for an atomic operation
+	ErrPreviousNotSpecified = errors.New("Previous K/V pair should be provided for the Atomic operation")
+)
+
+// Config contains the options for a storage client
+type Config struct {
+	ClientTLS         *ClientTLSConfig
+	TLS               *tls.Config
+	ConnectionTimeout time.Duration
+	Bucket            string
+	PersistConnection bool
+}
+
+// ClientTLSConfig contains data for a Client TLS configuration in the form
+// the etcd client wants it.  Eventually we'll adapt it for ZK and Consul.
+type ClientTLSConfig struct {
+	CertFile   string
+	KeyFile    string
+	CACertFile string
+}
+
+// Store represents the backend K/V storage
+// Each store should support every call listed
+// here. Or it couldn't be implemented as a K/V
+// backend for libkv
+type Store interface {
+	// Put a value at the specified key
+	Put(key string, value []byte, options *WriteOptions) error
+
+	// Get a value given its key
+	Get(key string) (*KVPair, error)
+
+	// Delete the value at the specified key
+	Delete(key string) error
+
+	// Verify if a Key exists in the store
+	Exists(key string) (bool, error)
+
+	// Watch for changes on a key
+	Watch(key string, stopCh <-chan struct{}) (<-chan *KVPair, error)
+
+	// WatchTree watches for changes on child nodes under
+	// a given directory
+	WatchTree(directory string, stopCh <-chan struct{}) (<-chan []*KVPair, error)
+
+	// NewLock creates a lock for a given key.
+	// The returned Locker is not held and must be acquired
+	// with `.Lock`. The Value is optional.
+	NewLock(key string, options *LockOptions) (Locker, error)
+
+	// List the content of a given prefix
+	List(directory string) ([]*KVPair, error)
+
+	// DeleteTree deletes a range of keys under a given directory
+	DeleteTree(directory string) error
+
+	// Atomic CAS operation on a single value.
+	// Pass previous = nil to create a new key.
+	AtomicPut(key string, value []byte, previous *KVPair, options *WriteOptions) (bool, *KVPair, error)
+
+	// Atomic delete of a single value
+	AtomicDelete(key string, previous *KVPair) (bool, error)
+
+	// Close the store connection
+	Close()
+}
+
+// KVPair represents {Key, Value, Lastindex} tuple
+type KVPair struct {
+	Key       string
+	Value     []byte
+	LastIndex uint64
+}
+
+// WriteOptions contains optional request parameters
+type WriteOptions struct {
+	IsDir bool
+	TTL   time.Duration
+}
+
+// LockOptions contains optional request parameters
+type LockOptions struct {
+	Value     []byte        // Optional, value to associate with the lock
+	TTL       time.Duration // Optional, expiration ttl associated with the lock
+	RenewLock chan struct{} // Optional, chan used to control and stop the session ttl renewal for the lock
+}
+
+// Locker provides locking mechanism on top of the store.
+// Similar to `sync.Lock` except it may return errors.
+type Locker interface {
+	Lock(stopChan chan struct{}) (<-chan struct{}, error)
+	Unlock() error
+}

--- a/vendor/github.com/docker/libkv/store/zookeeper/zookeeper.go
+++ b/vendor/github.com/docker/libkv/store/zookeeper/zookeeper.go
@@ -1,0 +1,411 @@
+package zookeeper
+
+import (
+	"strings"
+	"time"
+
+	"github.com/docker/libkv"
+	"github.com/docker/libkv/store"
+	zk "github.com/samuel/go-zookeeper/zk"
+)
+
+const (
+	// SOH control character
+	SOH = "\x01"
+
+	defaultTimeout = 10 * time.Second
+)
+
+// Zookeeper is the receiver type for
+// the Store interface
+type Zookeeper struct {
+	timeout time.Duration
+	client  *zk.Conn
+}
+
+type zookeeperLock struct {
+	client *zk.Conn
+	lock   *zk.Lock
+	key    string
+	value  []byte
+}
+
+// Register registers zookeeper to libkv
+func Register() {
+	libkv.AddStore(store.ZK, New)
+}
+
+// New creates a new Zookeeper client given a
+// list of endpoints and an optional tls config
+func New(endpoints []string, options *store.Config) (store.Store, error) {
+	s := &Zookeeper{}
+	s.timeout = defaultTimeout
+
+	// Set options
+	if options != nil {
+		if options.ConnectionTimeout != 0 {
+			s.setTimeout(options.ConnectionTimeout)
+		}
+	}
+
+	// Connect to Zookeeper
+	conn, _, err := zk.Connect(endpoints, s.timeout)
+	if err != nil {
+		return nil, err
+	}
+	s.client = conn
+
+	return s, nil
+}
+
+// setTimeout sets the timeout for connecting to Zookeeper
+func (s *Zookeeper) setTimeout(time time.Duration) {
+	s.timeout = time
+}
+
+// Get the value at "key", returns the last modified index
+// to use in conjunction to Atomic calls
+func (s *Zookeeper) Get(key string) (pair *store.KVPair, err error) {
+	resp, meta, err := s.client.Get(s.normalize(key))
+
+	if err != nil {
+		if err == zk.ErrNoNode {
+			return nil, store.ErrKeyNotFound
+		}
+		return nil, err
+	}
+
+	// FIXME handle very rare cases where Get returns the
+	// SOH control character instead of the actual value
+	if string(resp) == SOH {
+		return s.Get(store.Normalize(key))
+	}
+
+	pair = &store.KVPair{
+		Key:       key,
+		Value:     resp,
+		LastIndex: uint64(meta.Version),
+	}
+
+	return pair, nil
+}
+
+// createFullPath creates the entire path for a directory
+// that does not exist
+func (s *Zookeeper) createFullPath(path []string, ephemeral bool) error {
+	for i := 1; i <= len(path); i++ {
+		newpath := "/" + strings.Join(path[:i], "/")
+		if i == len(path) && ephemeral {
+			_, err := s.client.Create(newpath, []byte{}, zk.FlagEphemeral, zk.WorldACL(zk.PermAll))
+			return err
+		}
+		_, err := s.client.Create(newpath, []byte{}, 0, zk.WorldACL(zk.PermAll))
+		if err != nil {
+			// Skip if node already exists
+			if err != zk.ErrNodeExists {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// Put a value at "key"
+func (s *Zookeeper) Put(key string, value []byte, opts *store.WriteOptions) error {
+	fkey := s.normalize(key)
+
+	exists, err := s.Exists(key)
+	if err != nil {
+		return err
+	}
+
+	if !exists {
+		if opts != nil && opts.TTL > 0 {
+			s.createFullPath(store.SplitKey(strings.TrimSuffix(key, "/")), true)
+		} else {
+			s.createFullPath(store.SplitKey(strings.TrimSuffix(key, "/")), false)
+		}
+	}
+
+	_, err = s.client.Set(fkey, value, -1)
+	return err
+}
+
+// Delete a value at "key"
+func (s *Zookeeper) Delete(key string) error {
+	err := s.client.Delete(s.normalize(key), -1)
+	if err == zk.ErrNoNode {
+		return store.ErrKeyNotFound
+	}
+	return err
+}
+
+// Exists checks if the key exists inside the store
+func (s *Zookeeper) Exists(key string) (bool, error) {
+	exists, _, err := s.client.Exists(s.normalize(key))
+	if err != nil {
+		return false, err
+	}
+	return exists, nil
+}
+
+// Watch for changes on a "key"
+// It returns a channel that will receive changes or pass
+// on errors. Upon creation, the current value will first
+// be sent to the channel. Providing a non-nil stopCh can
+// be used to stop watching.
+func (s *Zookeeper) Watch(key string, stopCh <-chan struct{}) (<-chan *store.KVPair, error) {
+	// Get the key first
+	pair, err := s.Get(key)
+	if err != nil {
+		return nil, err
+	}
+
+	// Catch zk notifications and fire changes into the channel.
+	watchCh := make(chan *store.KVPair)
+	go func() {
+		defer close(watchCh)
+
+		// Get returns the current value to the channel prior
+		// to listening to any event that may occur on that key
+		watchCh <- pair
+		for {
+			_, _, eventCh, err := s.client.GetW(s.normalize(key))
+			if err != nil {
+				return
+			}
+			select {
+			case e := <-eventCh:
+				if e.Type == zk.EventNodeDataChanged {
+					if entry, err := s.Get(key); err == nil {
+						watchCh <- entry
+					}
+				}
+			case <-stopCh:
+				// There is no way to stop GetW so just quit
+				return
+			}
+		}
+	}()
+
+	return watchCh, nil
+}
+
+// WatchTree watches for changes on a "directory"
+// It returns a channel that will receive changes or pass
+// on errors. Upon creating a watch, the current childs values
+// will be sent to the channel .Providing a non-nil stopCh can
+// be used to stop watching.
+func (s *Zookeeper) WatchTree(directory string, stopCh <-chan struct{}) (<-chan []*store.KVPair, error) {
+	// List the childrens first
+	entries, err := s.List(directory)
+	if err != nil {
+		return nil, err
+	}
+
+	// Catch zk notifications and fire changes into the channel.
+	watchCh := make(chan []*store.KVPair)
+	go func() {
+		defer close(watchCh)
+
+		// List returns the children values to the channel
+		// prior to listening to any events that may occur
+		// on those keys
+		watchCh <- entries
+
+		for {
+			_, _, eventCh, err := s.client.ChildrenW(s.normalize(directory))
+			if err != nil {
+				return
+			}
+			select {
+			case e := <-eventCh:
+				if e.Type == zk.EventNodeChildrenChanged {
+					if kv, err := s.List(directory); err == nil {
+						watchCh <- kv
+					}
+				}
+			case <-stopCh:
+				// There is no way to stop GetW so just quit
+				return
+			}
+		}
+	}()
+
+	return watchCh, nil
+}
+
+// List child nodes of a given directory
+func (s *Zookeeper) List(directory string) ([]*store.KVPair, error) {
+	keys, stat, err := s.client.Children(s.normalize(directory))
+	if err != nil {
+		if err == zk.ErrNoNode {
+			return nil, store.ErrKeyNotFound
+		}
+		return nil, err
+	}
+
+	kv := []*store.KVPair{}
+
+	// FIXME Costly Get request for each child key..
+	for _, key := range keys {
+		pair, err := s.Get(strings.TrimSuffix(directory, "/") + s.normalize(key))
+		if err != nil {
+			// If node is not found: List is out of date, retry
+			if err == zk.ErrNoNode {
+				return s.List(directory)
+			}
+			return nil, err
+		}
+
+		kv = append(kv, &store.KVPair{
+			Key:       key,
+			Value:     []byte(pair.Value),
+			LastIndex: uint64(stat.Version),
+		})
+	}
+
+	return kv, nil
+}
+
+// DeleteTree deletes a range of keys under a given directory
+func (s *Zookeeper) DeleteTree(directory string) error {
+	pairs, err := s.List(directory)
+	if err != nil {
+		return err
+	}
+
+	var reqs []interface{}
+
+	for _, pair := range pairs {
+		reqs = append(reqs, &zk.DeleteRequest{
+			Path:    s.normalize(directory + "/" + pair.Key),
+			Version: -1,
+		})
+	}
+
+	_, err = s.client.Multi(reqs...)
+	return err
+}
+
+// AtomicPut put a value at "key" if the key has not been
+// modified in the meantime, throws an error if this is the case
+func (s *Zookeeper) AtomicPut(key string, value []byte, previous *store.KVPair, _ *store.WriteOptions) (bool, *store.KVPair, error) {
+
+	var lastIndex uint64
+	if previous != nil {
+		meta, err := s.client.Set(s.normalize(key), value, int32(previous.LastIndex))
+		if err != nil {
+			// Compare Failed
+			if err == zk.ErrBadVersion {
+				return false, nil, store.ErrKeyModified
+			}
+			return false, nil, err
+		}
+		lastIndex = uint64(meta.Version)
+	} else {
+		// Interpret previous == nil as create operation.
+		_, err := s.client.Create(s.normalize(key), value, 0, zk.WorldACL(zk.PermAll))
+		if err != nil {
+			// Zookeeper will complain if the directory doesn't exist.
+			if err == zk.ErrNoNode {
+				// Create the directory
+				parts := store.SplitKey(key)
+				parts = parts[:len(parts)-1]
+				if err = s.createFullPath(parts, false); err != nil {
+					// Failed to create the directory.
+					return false, nil, err
+				}
+				if _, err := s.client.Create(s.normalize(key), value, 0, zk.WorldACL(zk.PermAll)); err != nil {
+					return false, nil, err
+				}
+
+			} else {
+				// Unhandled error
+				return false, nil, err
+			}
+		}
+		lastIndex = 0 // Newly created nodes have version 0.
+	}
+
+	pair := &store.KVPair{
+		Key:       key,
+		Value:     value,
+		LastIndex: lastIndex,
+	}
+
+	return true, pair, nil
+}
+
+// AtomicDelete deletes a value at "key" if the key
+// has not been modified in the meantime, throws an
+// error if this is the case
+func (s *Zookeeper) AtomicDelete(key string, previous *store.KVPair) (bool, error) {
+	if previous == nil {
+		return false, store.ErrPreviousNotSpecified
+	}
+
+	err := s.client.Delete(s.normalize(key), int32(previous.LastIndex))
+	if err != nil {
+		if err == zk.ErrBadVersion {
+			return false, store.ErrKeyModified
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+// NewLock returns a handle to a lock struct which can
+// be used to provide mutual exclusion on a key
+func (s *Zookeeper) NewLock(key string, options *store.LockOptions) (lock store.Locker, err error) {
+	value := []byte("")
+
+	// Apply options
+	if options != nil {
+		if options.Value != nil {
+			value = options.Value
+		}
+	}
+
+	lock = &zookeeperLock{
+		client: s.client,
+		key:    s.normalize(key),
+		value:  value,
+		lock:   zk.NewLock(s.client, s.normalize(key), zk.WorldACL(zk.PermAll)),
+	}
+
+	return lock, err
+}
+
+// Lock attempts to acquire the lock and blocks while
+// doing so. It returns a channel that is closed if our
+// lock is lost or if an error occurs
+func (l *zookeeperLock) Lock(stopChan chan struct{}) (<-chan struct{}, error) {
+	err := l.lock.Lock()
+
+	if err == nil {
+		// We hold the lock, we can set our value
+		// FIXME: The value is left behind
+		// (problematic for leader election)
+		_, err = l.client.Set(l.key, l.value, -1)
+	}
+
+	return make(chan struct{}), err
+}
+
+// Unlock the "key". Calling unlock while
+// not holding the lock will throw an error
+func (l *zookeeperLock) Unlock() error {
+	return l.lock.Unlock()
+}
+
+// Close closes the client connection
+func (s *Zookeeper) Close() {
+	s.client.Close()
+}
+
+// Normalize the key for usage in Zookeeper
+func (s *Zookeeper) normalize(key string) string {
+	key = store.Normalize(key)
+	return strings.TrimSuffix(key, "/")
+}

--- a/vendor/github.com/docker/libkv/store/zookeeper/zookeeper_test.go
+++ b/vendor/github.com/docker/libkv/store/zookeeper/zookeeper_test.go
@@ -1,0 +1,54 @@
+package zookeeper
+
+import (
+	"testing"
+	"time"
+
+	"github.com/docker/libkv"
+	"github.com/docker/libkv/store"
+	"github.com/docker/libkv/testutils"
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	client = "localhost:2181"
+)
+
+func makeZkClient(t *testing.T) store.Store {
+	kv, err := New(
+		[]string{client},
+		&store.Config{
+			ConnectionTimeout: 3 * time.Second,
+		},
+	)
+
+	if err != nil {
+		t.Fatalf("cannot create store: %v", err)
+	}
+
+	return kv
+}
+
+func TestRegister(t *testing.T) {
+	Register()
+
+	kv, err := libkv.NewStore(store.ZK, []string{client}, nil)
+	assert.NoError(t, err)
+	assert.NotNil(t, kv)
+
+	if _, ok := kv.(*Zookeeper); !ok {
+		t.Fatal("Error registering and initializing zookeeper")
+	}
+}
+
+func TestZkStore(t *testing.T) {
+	kv := makeZkClient(t)
+	ttlKV := makeZkClient(t)
+
+	testutils.RunTestCommon(t, kv)
+	testutils.RunTestAtomic(t, kv)
+	testutils.RunTestWatch(t, kv)
+	testutils.RunTestLock(t, kv)
+	testutils.RunTestTTL(t, kv, ttlKV)
+	testutils.RunCleanup(t, kv)
+}

--- a/vendor/github.com/docker/libkv/testutils/utils.go
+++ b/vendor/github.com/docker/libkv/testutils/utils.go
@@ -1,0 +1,608 @@
+package testutils
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/docker/libkv/store"
+	"github.com/stretchr/testify/assert"
+)
+
+// RunTestCommon tests the minimal required APIs which
+// should be supported by all K/V backends
+func RunTestCommon(t *testing.T, kv store.Store) {
+	testPutGetDeleteExists(t, kv)
+	testList(t, kv)
+	testDeleteTree(t, kv)
+}
+
+// RunTestAtomic tests the Atomic operations by the K/V
+// backends
+func RunTestAtomic(t *testing.T, kv store.Store) {
+	testAtomicPut(t, kv)
+	testAtomicPutCreate(t, kv)
+	testAtomicDelete(t, kv)
+}
+
+// RunTestWatch tests the watch/monitor APIs supported
+// by the K/V backends.
+func RunTestWatch(t *testing.T, kv store.Store) {
+	testWatch(t, kv)
+	testWatchTree(t, kv)
+}
+
+// RunTestLock tests the KV pair Lock/Unlock APIs supported
+// by the K/V backends.
+func RunTestLock(t *testing.T, kv store.Store) {
+	testLockUnlock(t, kv)
+}
+
+// RunTestLockTTL tests the KV pair Lock with TTL APIs supported
+// by the K/V backends.
+func RunTestLockTTL(t *testing.T, kv store.Store, backup store.Store) {
+	testLockTTL(t, kv, backup)
+}
+
+// RunTestTTL tests the TTL funtionality of the K/V backend.
+func RunTestTTL(t *testing.T, kv store.Store, backup store.Store) {
+	testPutTTL(t, kv, backup)
+}
+
+func testPutGetDeleteExists(t *testing.T, kv store.Store) {
+	// Get a not exist key should return ErrKeyNotFound
+	pair, err := kv.Get("testPutGetDelete_not_exist_key")
+	assert.Equal(t, store.ErrKeyNotFound, err)
+
+	value := []byte("bar")
+	for _, key := range []string{
+		"testPutGetDeleteExists",
+		"testPutGetDeleteExists/",
+		"testPutGetDeleteExists/testbar/",
+		"testPutGetDeleteExists/testbar/testfoobar",
+	} {
+		failMsg := fmt.Sprintf("Fail key %s", key)
+
+		// Put the key
+		err = kv.Put(key, value, nil)
+		assert.NoError(t, err, failMsg)
+
+		// Get should return the value and an incremented index
+		pair, err = kv.Get(key)
+		assert.NoError(t, err, failMsg)
+		if assert.NotNil(t, pair, failMsg) {
+			assert.NotNil(t, pair.Value, failMsg)
+		}
+		assert.Equal(t, pair.Value, value, failMsg)
+		assert.NotEqual(t, pair.LastIndex, 0, failMsg)
+
+		// Exists should return true
+		exists, err := kv.Exists(key)
+		assert.NoError(t, err, failMsg)
+		assert.True(t, exists, failMsg)
+
+		// Delete the key
+		err = kv.Delete(key)
+		assert.NoError(t, err, failMsg)
+
+		// Get should fail
+		pair, err = kv.Get(key)
+		assert.Error(t, err, failMsg)
+		assert.Nil(t, pair, failMsg)
+
+		// Exists should return false
+		exists, err = kv.Exists(key)
+		assert.NoError(t, err, failMsg)
+		assert.False(t, exists, failMsg)
+	}
+}
+
+func testWatch(t *testing.T, kv store.Store) {
+	key := "testWatch"
+	value := []byte("world")
+	newValue := []byte("world!")
+
+	// Put the key
+	err := kv.Put(key, value, nil)
+	assert.NoError(t, err)
+
+	stopCh := make(<-chan struct{})
+	events, err := kv.Watch(key, stopCh)
+	assert.NoError(t, err)
+	assert.NotNil(t, events)
+
+	// Update loop
+	go func() {
+		timeout := time.After(1 * time.Second)
+		tick := time.Tick(250 * time.Millisecond)
+		for {
+			select {
+			case <-timeout:
+				return
+			case <-tick:
+				err := kv.Put(key, newValue, nil)
+				if assert.NoError(t, err) {
+					continue
+				}
+				return
+			}
+		}
+	}()
+
+	// Check for updates
+	eventCount := 1
+	for {
+		select {
+		case event := <-events:
+			assert.NotNil(t, event)
+			if eventCount == 1 {
+				assert.Equal(t, event.Key, key)
+				assert.Equal(t, event.Value, value)
+			} else {
+				assert.Equal(t, event.Key, key)
+				assert.Equal(t, event.Value, newValue)
+			}
+			eventCount++
+			// We received all the events we wanted to check
+			if eventCount >= 4 {
+				return
+			}
+		case <-time.After(4 * time.Second):
+			t.Fatal("Timeout reached")
+			return
+		}
+	}
+}
+
+func testWatchTree(t *testing.T, kv store.Store) {
+	dir := "testWatchTree"
+
+	node1 := "testWatchTree/node1"
+	value1 := []byte("node1")
+
+	node2 := "testWatchTree/node2"
+	value2 := []byte("node2")
+
+	node3 := "testWatchTree/node3"
+	value3 := []byte("node3")
+
+	err := kv.Put(node1, value1, nil)
+	assert.NoError(t, err)
+	err = kv.Put(node2, value2, nil)
+	assert.NoError(t, err)
+	err = kv.Put(node3, value3, nil)
+	assert.NoError(t, err)
+
+	stopCh := make(<-chan struct{})
+	events, err := kv.WatchTree(dir, stopCh)
+	assert.NoError(t, err)
+	assert.NotNil(t, events)
+
+	// Update loop
+	go func() {
+		timeout := time.After(500 * time.Millisecond)
+		for {
+			select {
+			case <-timeout:
+				err := kv.Delete(node3)
+				assert.NoError(t, err)
+				return
+			}
+		}
+	}()
+
+	// Check for updates
+	eventCount := 1
+	for {
+		select {
+		case event := <-events:
+			assert.NotNil(t, event)
+			// We received the Delete event on a child node
+			// Exit test successfully
+			if eventCount == 2 {
+				return
+			}
+			eventCount++
+		case <-time.After(4 * time.Second):
+			t.Fatal("Timeout reached")
+			return
+		}
+	}
+}
+
+func testAtomicPut(t *testing.T, kv store.Store) {
+	key := "testAtomicPut"
+	value := []byte("world")
+
+	// Put the key
+	err := kv.Put(key, value, nil)
+	assert.NoError(t, err)
+
+	// Get should return the value and an incremented index
+	pair, err := kv.Get(key)
+	assert.NoError(t, err)
+	if assert.NotNil(t, pair) {
+		assert.NotNil(t, pair.Value)
+	}
+	assert.Equal(t, pair.Value, value)
+	assert.NotEqual(t, pair.LastIndex, 0)
+
+	// This CAS should fail: previous exists.
+	success, _, err := kv.AtomicPut(key, []byte("WORLD"), nil, nil)
+	assert.Error(t, err)
+	assert.False(t, success)
+
+	// This CAS should succeed
+	success, _, err = kv.AtomicPut(key, []byte("WORLD"), pair, nil)
+	assert.NoError(t, err)
+	assert.True(t, success)
+
+	// This CAS should fail, key exists.
+	pair.LastIndex = 6744
+	success, _, err = kv.AtomicPut(key, []byte("WORLDWORLD"), pair, nil)
+	assert.Error(t, err)
+	assert.False(t, success)
+}
+
+func testAtomicPutCreate(t *testing.T, kv store.Store) {
+	// Use a key in a new directory to ensure Stores will create directories
+	// that don't yet exist.
+	key := "testAtomicPutCreate/create"
+	value := []byte("putcreate")
+
+	// AtomicPut the key, previous = nil indicates create.
+	success, _, err := kv.AtomicPut(key, value, nil, nil)
+	assert.NoError(t, err)
+	assert.True(t, success)
+
+	// Get should return the value and an incremented index
+	pair, err := kv.Get(key)
+	assert.NoError(t, err)
+	if assert.NotNil(t, pair) {
+		assert.NotNil(t, pair.Value)
+	}
+	assert.Equal(t, pair.Value, value)
+
+	// Attempting to create again should fail.
+	success, _, err = kv.AtomicPut(key, value, nil, nil)
+	assert.Error(t, err)
+	assert.False(t, success)
+
+	// This CAS should succeed, since it has the value from Get()
+	success, _, err = kv.AtomicPut(key, []byte("PUTCREATE"), pair, nil)
+	assert.NoError(t, err)
+	assert.True(t, success)
+}
+
+func testAtomicDelete(t *testing.T, kv store.Store) {
+	key := "testAtomicDelete"
+	value := []byte("world")
+
+	// Put the key
+	err := kv.Put(key, value, nil)
+	assert.NoError(t, err)
+
+	// Get should return the value and an incremented index
+	pair, err := kv.Get(key)
+	assert.NoError(t, err)
+	if assert.NotNil(t, pair) {
+		assert.NotNil(t, pair.Value)
+	}
+	assert.Equal(t, pair.Value, value)
+	assert.NotEqual(t, pair.LastIndex, 0)
+
+	tempIndex := pair.LastIndex
+
+	// AtomicDelete should fail
+	pair.LastIndex = 6744
+	success, err := kv.AtomicDelete(key, pair)
+	assert.Error(t, err)
+	assert.False(t, success)
+
+	// AtomicDelete should succeed
+	pair.LastIndex = tempIndex
+	success, err = kv.AtomicDelete(key, pair)
+	assert.NoError(t, err)
+	assert.True(t, success)
+}
+
+func testLockUnlock(t *testing.T, kv store.Store) {
+	key := "testLockUnlock"
+	value := []byte("bar")
+
+	// We should be able to create a new lock on key
+	lock, err := kv.NewLock(key, &store.LockOptions{Value: value, TTL: 2 * time.Second})
+	assert.NoError(t, err)
+	assert.NotNil(t, lock)
+
+	// Lock should successfully succeed or block
+	lockChan, err := lock.Lock(nil)
+	assert.NoError(t, err)
+	assert.NotNil(t, lockChan)
+
+	// Get should work
+	pair, err := kv.Get(key)
+	assert.NoError(t, err)
+	if assert.NotNil(t, pair) {
+		assert.NotNil(t, pair.Value)
+	}
+	assert.Equal(t, pair.Value, value)
+	assert.NotEqual(t, pair.LastIndex, 0)
+
+	// Unlock should succeed
+	err = lock.Unlock()
+	assert.NoError(t, err)
+
+	// Lock should succeed again
+	lockChan, err = lock.Lock(nil)
+	assert.NoError(t, err)
+	assert.NotNil(t, lockChan)
+
+	// Get should work
+	pair, err = kv.Get(key)
+	assert.NoError(t, err)
+	if assert.NotNil(t, pair) {
+		assert.NotNil(t, pair.Value)
+	}
+	assert.Equal(t, pair.Value, value)
+	assert.NotEqual(t, pair.LastIndex, 0)
+
+	err = lock.Unlock()
+	assert.NoError(t, err)
+}
+
+func testLockTTL(t *testing.T, kv store.Store, otherConn store.Store) {
+	key := "testLockTTL"
+	value := []byte("bar")
+
+	renewCh := make(chan struct{})
+
+	// We should be able to create a new lock on key
+	lock, err := otherConn.NewLock(key, &store.LockOptions{
+		Value:     value,
+		TTL:       2 * time.Second,
+		RenewLock: renewCh,
+	})
+	assert.NoError(t, err)
+	assert.NotNil(t, lock)
+
+	// Lock should successfully succeed
+	lockChan, err := lock.Lock(nil)
+	assert.NoError(t, err)
+	assert.NotNil(t, lockChan)
+
+	// Get should work
+	pair, err := otherConn.Get(key)
+	assert.NoError(t, err)
+	if assert.NotNil(t, pair) {
+		assert.NotNil(t, pair.Value)
+	}
+	assert.Equal(t, pair.Value, value)
+	assert.NotEqual(t, pair.LastIndex, 0)
+
+	time.Sleep(3 * time.Second)
+
+	done := make(chan struct{})
+	stop := make(chan struct{})
+
+	value = []byte("foobar")
+
+	// Create a new lock with another connection
+	lock, err = kv.NewLock(
+		key,
+		&store.LockOptions{
+			Value: value,
+			TTL:   3 * time.Second,
+		},
+	)
+	assert.NoError(t, err)
+	assert.NotNil(t, lock)
+
+	// Lock should block, the session on the lock
+	// is still active and renewed periodically
+	go func(<-chan struct{}) {
+		_, _ = lock.Lock(stop)
+		done <- struct{}{}
+	}(done)
+
+	select {
+	case _ = <-done:
+		t.Fatal("Lock succeeded on a key that is supposed to be locked by another client")
+	case <-time.After(4 * time.Second):
+		// Stop requesting the lock as we are blocked as expected
+		stop <- struct{}{}
+		break
+	}
+
+	// Close the connection
+	otherConn.Close()
+
+	// Force stop the session renewal for the lock
+	close(renewCh)
+
+	// Let the session on the lock expire
+	time.Sleep(3 * time.Second)
+	locked := make(chan struct{})
+
+	// Lock should now succeed for the other client
+	go func(<-chan struct{}) {
+		lockChan, err = lock.Lock(nil)
+		assert.NoError(t, err)
+		assert.NotNil(t, lockChan)
+		locked <- struct{}{}
+	}(locked)
+
+	select {
+	case _ = <-locked:
+		break
+	case <-time.After(4 * time.Second):
+		t.Fatal("Unable to take the lock, timed out")
+	}
+
+	// Get should work with the new value
+	pair, err = kv.Get(key)
+	assert.NoError(t, err)
+	if assert.NotNil(t, pair) {
+		assert.NotNil(t, pair.Value)
+	}
+	assert.Equal(t, pair.Value, value)
+	assert.NotEqual(t, pair.LastIndex, 0)
+
+	err = lock.Unlock()
+	assert.NoError(t, err)
+}
+
+func testPutTTL(t *testing.T, kv store.Store, otherConn store.Store) {
+	firstKey := "testPutTTL"
+	firstValue := []byte("foo")
+
+	secondKey := "second"
+	secondValue := []byte("bar")
+
+	// Put the first key with the Ephemeral flag
+	err := otherConn.Put(firstKey, firstValue, &store.WriteOptions{TTL: 2 * time.Second})
+	assert.NoError(t, err)
+
+	// Put a second key with the Ephemeral flag
+	err = otherConn.Put(secondKey, secondValue, &store.WriteOptions{TTL: 2 * time.Second})
+	assert.NoError(t, err)
+
+	// Get on firstKey should work
+	pair, err := kv.Get(firstKey)
+	assert.NoError(t, err)
+	assert.NotNil(t, pair)
+
+	// Get on secondKey should work
+	pair, err = kv.Get(secondKey)
+	assert.NoError(t, err)
+	assert.NotNil(t, pair)
+
+	// Close the connection
+	otherConn.Close()
+
+	// Let the session expire
+	time.Sleep(3 * time.Second)
+
+	// Get on firstKey shouldn't work
+	pair, err = kv.Get(firstKey)
+	assert.Error(t, err)
+	assert.Nil(t, pair)
+
+	// Get on secondKey shouldn't work
+	pair, err = kv.Get(secondKey)
+	assert.Error(t, err)
+	assert.Nil(t, pair)
+}
+
+func testList(t *testing.T, kv store.Store) {
+	prefix := "testList"
+
+	firstKey := "testList/first"
+	firstValue := []byte("first")
+
+	secondKey := "testList/second"
+	secondValue := []byte("second")
+
+	// Put the first key
+	err := kv.Put(firstKey, firstValue, nil)
+	assert.NoError(t, err)
+
+	// Put the second key
+	err = kv.Put(secondKey, secondValue, nil)
+	assert.NoError(t, err)
+
+	// List should work and return the two correct values
+	for _, parent := range []string{prefix, prefix + "/"} {
+		pairs, err := kv.List(parent)
+		assert.NoError(t, err)
+		if assert.NotNil(t, pairs) {
+			assert.Equal(t, len(pairs), 2)
+		}
+
+		// Check pairs, those are not necessarily in Put order
+		for _, pair := range pairs {
+			if pair.Key == firstKey {
+				assert.Equal(t, pair.Value, firstValue)
+			}
+			if pair.Key == secondKey {
+				assert.Equal(t, pair.Value, secondValue)
+			}
+		}
+	}
+
+	// List should fail: the key does not exist
+	pairs, err := kv.List("idontexist")
+	assert.Equal(t, store.ErrKeyNotFound, err)
+	assert.Nil(t, pairs)
+}
+
+func testDeleteTree(t *testing.T, kv store.Store) {
+	prefix := "testDeleteTree"
+
+	firstKey := "testDeleteTree/first"
+	firstValue := []byte("first")
+
+	secondKey := "testDeleteTree/second"
+	secondValue := []byte("second")
+
+	// Put the first key
+	err := kv.Put(firstKey, firstValue, nil)
+	assert.NoError(t, err)
+
+	// Put the second key
+	err = kv.Put(secondKey, secondValue, nil)
+	assert.NoError(t, err)
+
+	// Get should work on the first Key
+	pair, err := kv.Get(firstKey)
+	assert.NoError(t, err)
+	if assert.NotNil(t, pair) {
+		assert.NotNil(t, pair.Value)
+	}
+	assert.Equal(t, pair.Value, firstValue)
+	assert.NotEqual(t, pair.LastIndex, 0)
+
+	// Get should work on the second Key
+	pair, err = kv.Get(secondKey)
+	assert.NoError(t, err)
+	if assert.NotNil(t, pair) {
+		assert.NotNil(t, pair.Value)
+	}
+	assert.Equal(t, pair.Value, secondValue)
+	assert.NotEqual(t, pair.LastIndex, 0)
+
+	// Delete Values under directory `nodes`
+	err = kv.DeleteTree(prefix)
+	assert.NoError(t, err)
+
+	// Get should fail on both keys
+	pair, err = kv.Get(firstKey)
+	assert.Error(t, err)
+	assert.Nil(t, pair)
+
+	pair, err = kv.Get(secondKey)
+	assert.Error(t, err)
+	assert.Nil(t, pair)
+}
+
+// RunCleanup cleans up keys introduced by the tests
+func RunCleanup(t *testing.T, kv store.Store) {
+	for _, key := range []string{
+		"testPutGetDeleteExists",
+		"testWatch",
+		"testWatchTree",
+		"testAtomicPut",
+		"testAtomicPutCreate",
+		"testAtomicDelete",
+		"testLockUnlock",
+		"testLockTTL",
+		"testPutTTL",
+		"testList",
+		"testDeleteTree",
+	} {
+		err := kv.DeleteTree(key)
+		assert.True(t, err == nil || err == store.ErrKeyNotFound, fmt.Sprintf("failed to delete tree key %s: %v", key, err))
+		err = kv.Delete(key)
+		assert.True(t, err == nil || err == store.ErrKeyNotFound, fmt.Sprintf("failed to delete key %s: %v", key, err))
+	}
+}


### PR DESCRIPTION
Store the inventory in the KV store (see #1). This adds a new CLI flag, `--kv-url`, for storing information (currently just inventory) in an etcd KV store. This leaves all the machine directory stuff intact in the `storage-path`. Other changes in this project will reduce what's there, and we can eventually split machine drivers into "local" and "remote" drivers to determine which ones can be run in a team mode.

This should be demoable, or nearly so: `ls`, `ssh`, `env`, `create`, and `rm` all work with the KVM driver.

Things to cleanup:

1) Log messages with `AK` should either be eliminated or changed to `KV` or something.
2) Make sure I didn't clobber any of the remote CA stuff and ideally that a fast-foward merge is possible.
3) More testing
4) Clean up naming in `libmachine/kv/kv.go` and maybe remove some paranoid guards?
